### PR TITLE
Simple support for ArrayAdapter equality

### DIFF
--- a/biggus.py
+++ b/biggus.py
@@ -123,6 +123,14 @@ class ArrayAdapter(Array):
         shape = _sliced_shape(self._concrete.shape, self._keys)
         return shape
 
+    def __eq__(self, other):
+        result = NotImplemented
+        if isinstance(other, ArrayAdapter):
+            result = self._concrete == other._concrete
+            if isinstance(result, numpy.ndarray):
+                result = numpy.all(result)
+        return result
+
     def _cleanup_new_key(self, key, size, axis):
         """
         Return a key of type int, slice, or tuple that is guaranteed


### PR DESCRIPTION
Allows the concrete instance to return either a simple boolean or an array of type boolean - the latter is what numpy.ndarray will do.
