### PR TITLE
Remove usage of concrete.ndim

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -111,13 +111,13 @@ class ArrayAdapter(Array):
 
     """
     def __init__(self, concrete, keys=()):
-        # concrete has:
+        # concrete must have:
         #   dtype
-        #   ndim
+        #   shape
         self._concrete = concrete
         if not isinstance(keys, tuple):
             keys = (keys,)
-        assert len(keys) <= concrete.ndim
+        assert len(keys) <= len(concrete.shape)
         result_keys = []
         for axis, (key, size) in enumerate(zip(keys, concrete.shape)):
             result_key = self._cleanup_new_key(key, size, axis)

--- a/biggus/tests/test_adapter.py
+++ b/biggus/tests/test_adapter.py
@@ -138,6 +138,19 @@ class TestAdapter(unittest.TestCase):
                              '\nKeys: {!r}'.format(src_keys))
             np.testing.assert_array_equal(result, target)
 
+    def test_no_ndim(self):
+        # The concrete instance should not be need to provide `ndim` for
+        # the adapter to construct.
+        class Fake(object):
+            pass
+        ok = Fake()
+        ok.shape = (3, 4)
+        array = biggus.ArrayAdapter(ok)
+
+        no_shape = Fake()
+        with self.assertRaises(AttributeError):
+            array = biggus.ArrayAdapter(no_shape)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This allows ArrayAdapter to work with h5py datasets.
