### PR TITLE
Split ortho/fancy indexing adapters.

### DIFF
--- a/biggus/tests/test_aggregation.py
+++ b/biggus/tests/test_aggregation.py
@@ -72,7 +72,7 @@ class TestAggregation(unittest.TestCase):
             # Check the aggregation operation doesn't actually read any
             # data.
             data = _AccessCounter(raw_data)
-            array = biggus.ArrayAdapter(data)
+            array = biggus.NumpyArrayAdapter(data)
             op_array = biggus_op(array, axis=0, **kwargs)
             self.assertIsInstance(op_array, biggus.Array)
             self.assertTrue((data.counts == 0).all())
@@ -80,7 +80,7 @@ class TestAggregation(unittest.TestCase):
             # Compute the NumPy aggregation, and then wrap the result as
             # an array so we can apply biggus-style indexing.
             numpy_op_data = numpy_op(raw_data, axis=axis, **kwargs)
-            numpy_op_array = biggus.ArrayAdapter(numpy_op_data)
+            numpy_op_array = biggus.NumpyArrayAdapter(numpy_op_data)
 
             for keys in cuts:
                 # Check slicing doesn't actually read any data.

--- a/biggus/tests/test_linear_mosaic.py
+++ b/biggus/tests/test_linear_mosaic.py
@@ -24,7 +24,7 @@ import biggus
 class TestLinearMosaic(unittest.TestCase):
     def _tile(self, shape, dtype='f4'):
         data = np.arange(np.product(shape), dtype=dtype).reshape(shape)
-        return biggus.ArrayAdapter(data)
+        return biggus.NumpyArrayAdapter(data)
 
     def test_init(self):
         # Simple

--- a/biggus/tests/test_ndarray.py
+++ b/biggus/tests/test_ndarray.py
@@ -57,7 +57,7 @@ class TestNdarray(unittest.TestCase):
         size = numpy.prod(shape)
         raw_data = numpy.linspace(0, 1, num=size).reshape(shape)
         data = _AccessCounter(raw_data)
-        array = biggus.ArrayAdapter(data)
+        array = biggus.NumpyArrayAdapter(data)
         mean_array = biggus.mean(array, axis=0)
         std_array = biggus.std(array, axis=0)
         self.assertIsInstance(mean_array, biggus.Array)

--- a/biggus/tests/test_save.py
+++ b/biggus/tests/test_save.py
@@ -52,7 +52,7 @@ class TestWritePattern(unittest.TestCase):
     def _small_array(self):
         shape = (768, 1024)
         data = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
-        array = biggus.ArrayAdapter(data)
+        array = biggus.NumpyArrayAdapter(data)
         return array
 
     def test_small(self):
@@ -75,7 +75,7 @@ class TestNumbers(unittest.TestCase):
     # Check the numeric results of the save operation.
     def test_numbers(self):
         data = np.arange(12, dtype=np.float32).reshape(3, 4) + 10
-        array = biggus.ArrayAdapter(data)
+        array = biggus.NumpyArrayAdapter(data)
         target = np.zeros((3, 4))
         biggus.save([array], [target])
         np.testing.assert_array_equal(data, target)

--- a/biggus/tests/test_stack.py
+++ b/biggus/tests/test_stack.py
@@ -24,7 +24,7 @@ import biggus
 class TestStack(unittest.TestCase):
     def test_dtype(self):
         dtype = np.dtype('f4')
-        item = biggus.ArrayAdapter(np.empty(6, dtype=dtype))
+        item = biggus.NumpyArrayAdapter(np.empty(6, dtype=dtype))
         stack = np.array([item], dtype='O')
         array = biggus.ArrayStack(stack)
         self.assertEqual(array.dtype, dtype)
@@ -70,7 +70,7 @@ class TestStack(unittest.TestCase):
         for stack_shape, item_shape, cuts, target in tests:
             def make_array(*n):
                 concrete = np.empty(item_shape, dtype)
-                array = biggus.ArrayAdapter(concrete)
+                array = biggus.NumpyArrayAdapter(concrete)
                 return array
             stack = np.empty(stack_shape, dtype='O')
             for index in np.ndindex(stack.shape):
@@ -105,7 +105,7 @@ class TestStack(unittest.TestCase):
                 start = np.ravel_multi_index(index, stack_shape) * item_size
                 concrete = np.arange(item_size).reshape(item_shape)
                 concrete += start
-                array = biggus.ArrayAdapter(concrete)
+                array = biggus.NumpyArrayAdapter(concrete)
                 stack[index] = array
             array = biggus.ArrayStack(stack)
             result = array.ndarray()


### PR DESCRIPTION
This is a _backwards incompatible_ change to treat "fancy indexing" and "orthogonal indexing" data sources separately. For orthogonal data sources (such as netCDF4.Variable instances), this has two benefits for the ndarray()/masked_array() methods:
- It avoids unnecessary work and memory overhead from doing dimension-by-dimension slicing.
- It allows them to return "well-behaved" arrays that are C contiguous.

Fixes #39.
