### PR TITLE
Preserve array order

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -318,9 +318,7 @@ class NumpyArrayAdapter(_ArrayAdapter):
                 array = self._concrete
             # ... and then do each tuple in turn.
             for i, key in tuple_keys:
-                cut_keys = [slice(None)] * dimensions[i]
-                cut_keys.append(key)
-                array = array[tuple(cut_keys)]
+                array = np.take(array, key, axis=dimensions[i])
         else:
             array = self._concrete.__getitem__(keys)
         return array

--- a/biggus/tests/test_adapter.py
+++ b/biggus/tests/test_adapter.py
@@ -108,7 +108,7 @@ class _TestAdapter(unittest.TestCase):
                 for cut in cuts:
                     array = array.__getitem__(cut)
                     self.assertIsInstance(array, biggus.Array)
-                msg = '\nCuts: {!r}'.format(cuts)
+                msg = '\nSrc shape: {!r}\nCuts: {!r}'.format(src_shape, cuts)
                 self.assertEqual(array.shape, target, msg)
                 ndarray = array.ndarray()
                 self.assertEqual(ndarray.shape, target, msg)


### PR DESCRIPTION
Using step-by-step "fancy indexing" to mimic orthogonal indexing leaves the final array with an unexpected order. This PR avoids this by using `np.take(..., axis=...)` instead.

Each fancy-indexing operation creates a new array with the fancy-indexed dimension moved to the front. Then NumPy takes a view of this new array to move the fancy-indexed dimension back to where in belongs.
