### PR TITLE
Add variance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# Created by editors
+*~
+\#*
+\.\#*
+*.swp

--- a/biggus/tests/test_aggregation.py
+++ b/biggus/tests/test_aggregation.py
@@ -78,6 +78,10 @@ class TestAggregation(unittest.TestCase):
         self._test_aggregation(biggus.std, np.std, ddof=0)
         self._test_aggregation(biggus.std, np.std, ddof=1)
 
+    def test_var(self):
+        self._test_aggregation(biggus.var, np.var, ddof=0)
+        self._test_aggregation(biggus.var, np.var, ddof=1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/biggus/tests/unit/test_mean.py
+++ b/biggus/tests/unit/test_mean.py
@@ -1,0 +1,96 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Biggus.
+#
+# Biggus is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Biggus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for `biggus.mean`."""
+
+import numpy as np
+import unittest
+
+import biggus
+from biggus import mean
+
+
+class TestInvalidAxis(unittest.TestCase):
+    def setUp(self):
+        self.array = biggus.NumpyArrayAdapter(np.arange(12))
+
+    def test_none(self):
+        with self.assertRaises(AssertionError):
+            mean(self.array)
+
+    def test_non_zero(self):
+        with self.assertRaises(AssertionError):
+            mean(self.array, axis=1)
+
+    def test_multiple(self):
+        array = biggus.NumpyArrayAdapter(np.arange(12).reshape(3, 4))
+        with self.assertRaises(AssertionError):
+            mean(array, axis=(0, 1))
+
+
+class TestAggregationDtype(unittest.TestCase):
+    def _check(self, source, target):
+        array = biggus.NumpyArrayAdapter(np.arange(2, dtype=source))
+        agg = mean(array, axis=0)
+        self.assertEqual(agg.dtype, target)
+
+    def test_int_to_float(self):
+        dtypes = [np.int8, np.int16, np.int32, np.int]
+        for dtype in dtypes:
+            self._check(dtype, np.float)
+
+    def test_bool_to_float(self):
+        self._check(np.bool, np.float)
+
+    def test_floats(self):
+        dtypes = [np.float16, np.float32, np.float]
+        for dtype in dtypes:
+            self._check(dtype, dtype)
+
+    def test_complex(self):
+        self._check(np.complex, np.complex)
+
+
+class TestNumpyArrayAdapter(unittest.TestCase):
+    def setUp(self):
+        self.data = np.arange(12)
+
+    def _check(self, data, dtype=None, shape=None):
+        data = np.asarray(data, dtype=dtype)
+        if shape is not None:
+            data = data.reshape(shape)
+        array = biggus.NumpyArrayAdapter(data)
+        result = mean(array, axis=0).ndarray()
+        expected = np.mean(data, axis=0)
+        if expected.ndim == 0:
+            expected = np.asarray(expected)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_flat_int(self):
+        self._check(self.data)
+
+    def test_multi_int(self):
+        self._check(self.data, shape=(3, 4))
+
+    def test_flat_float(self):
+        self._check(self.data, dtype=np.float)
+
+    def test_multi_float(self):
+        self._check(self.data, dtype=np.float, shape=(3, 4))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/biggus/tests/unit/test_std_var.py
+++ b/biggus/tests/unit/test_std_var.py
@@ -1,0 +1,108 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of Biggus.
+#
+# Biggus is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Biggus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for `biggus.std` and `biggus.var`."""
+
+import numpy as np
+import unittest
+
+import biggus
+from biggus import std, var
+
+
+class TestInvalidAxis(unittest.TestCase):
+    def setUp(self):
+        self.funcs = [std, var]
+        self.array = biggus.NumpyArrayAdapter(np.arange(12))
+
+    def test_none(self):
+        for func in self.funcs:
+            with self.assertRaises(AssertionError):
+                func(self.array)
+
+    def test_non_zero(self):
+        for func in self.funcs:
+            with self.assertRaises(AssertionError):
+                func(self.array, axis=1)
+
+    def test_multiple(self):
+        for func in self.funcs:
+            array = biggus.NumpyArrayAdapter(np.arange(12).reshape(3, 4))
+            with self.assertRaises(AssertionError):
+                func(array, axis=(0, 1))
+
+
+class TestAggregationDtype(unittest.TestCase):
+    def _check(self, source, target):
+        funcs = (std, var)
+        for func in funcs:
+            array = biggus.NumpyArrayAdapter(np.arange(2, dtype=source))
+            agg = func(array, axis=0)
+            self.assertEqual(agg.dtype, target)
+
+    def test_int_to_float(self):
+        dtypes = [np.int8, np.int16, np.int32, np.int]
+        for dtype in dtypes:
+            self._check(dtype, np.float)
+
+    def test_bool_to_float(self):
+        self._check(np.bool, np.float)
+
+    def test_floats(self):
+        dtypes = [np.float16, np.float32, np.float]
+        for dtype in dtypes:
+            self._check(dtype, dtype)
+
+    def test_complex(self):
+        self._check(np.complex, np.complex)
+
+
+class TestNumpyArrayAdapter(unittest.TestCase):
+    def setUp(self):
+        self.funcs = [(std, np.std), (var, np.var)]
+        self.data = np.arange(12)
+
+    def _check(self, data, dtype=None, shape=None, ddof=0):
+        for bfunc, nfunc in self.funcs:
+            data = np.asarray(data, dtype=dtype)
+            if shape is not None:
+                data = data.reshape(shape)
+            array = biggus.NumpyArrayAdapter(data)
+            result = bfunc(array, axis=0, ddof=ddof).ndarray()
+            expected = nfunc(data, axis=0, ddof=ddof)
+            if expected.ndim == 0:
+                expected = np.asarray(expected)
+            np.testing.assert_array_equal(result, expected)
+
+    def test_flat_int(self):
+        for ddof in range(2):
+            self._check(self.data, ddof=ddof)
+
+    def test_multi_int(self):
+        for ddof in range(2):
+            self._check(self.data, shape=(3, 4), ddof=ddof)
+
+    def test_flat_float(self):
+        for ddof in range(2):
+            self._check(self.data, dtype=np.float, ddof=ddof)
+
+    def test_multi_float(self):
+        for ddof in range(2):
+            self._check(self.data, dtype=np.float, shape=(3, 4), ddof=ddof)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds the variance operator and corrects the mean and standard deviation operators which incorrectly handled integer data i.e. integer truncation by `dtype` was occurring.
