### PR TITLE
Allow string dtypes in stacks/mosaics.

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -776,13 +776,19 @@ class ArrayStack(Array):
         item_shape = first_array.shape
         dtype = first_array.dtype
         fill_value = first_array.fill_value
-        fill_value_is_nan = np.isnan(fill_value)
+        if np.issubdtype(dtype, np.floating):
+            def fill_value_ok(array):
+                return array.fill_value == fill_value or (
+                    np.isnan(fill_value) and np.isnan(array.fill_value))
+        else:
+            def fill_value_ok(array):
+                return array.fill_value == fill_value
         for array in stack.flat:
-            both_nan = fill_value_is_nan and np.isnan(array.fill_value)
             ok = (array.shape == item_shape and array.dtype == dtype and
-                  (fill_value == array.fill_value or both_nan))
+                  fill_value_ok(array))
             if not ok:
                 raise ValueError('invalid sub-array')
+
         self._stack = stack
         self._item_shape = item_shape
         self._dtype = dtype
@@ -864,7 +870,13 @@ class LinearMosaic(Array):
         common_shape = list(first.shape)
         common_dtype = first.dtype
         common_fill_value = first.fill_value
-        common_fill_value_is_nan = np.isnan(common_fill_value)
+        if np.issubdtype(common_dtype, np.floating):
+            def fill_value_ok(array):
+                return array.fill_value == common_fill_value or (
+                    np.isnan(common_fill_value) and np.isnan(array.fill_value))
+        else:
+            def fill_value_ok(array):
+                return array.fill_value == common_fill_value
         del common_shape[axis]
         for tile in tiles[1:]:
             shape = list(tile.shape)
@@ -873,8 +885,7 @@ class LinearMosaic(Array):
                 raise ValueError('inconsistent tile shapes')
             if tile.dtype != common_dtype:
                 raise ValueError('inconsistent tile dtypes')
-            both_nan = common_fill_value_is_nan and np.isnan(tile.fill_value)
-            if (common_fill_value != tile.fill_value and not both_nan):
+            if not fill_value_ok(tile):
                 raise ValueError('inconsistent tile fill_values')
         self._tiles = tiles
         self._axis = axis

--- a/biggus/tests/unit/test_ArrayStack.py
+++ b/biggus/tests/unit/test_ArrayStack.py
@@ -24,8 +24,8 @@ import numpy as np
 from biggus import ArrayStack
 
 
-def fake_array(fill_value):
-    return mock.Mock(shape=mock.sentinel.SHAPE, dtype=mock.sentinel.DTYPE,
+def fake_array(fill_value, dtype=np.dtype('f4')):
+    return mock.Mock(shape=mock.sentinel.SHAPE, dtype=dtype,
                      fill_value=fill_value)
 
 
@@ -57,6 +57,18 @@ class Test___init___fill_values(unittest.TestCase):
     def test_number_other_number(self):
         array1 = fake_array(42)
         array2 = fake_array(43)
+        with self.assertRaises(ValueError):
+            stack = ArrayStack(np.array([array1, array2]))
+
+    def test_matching_strings(self):
+        array1 = fake_array('foo', np.dtype('S3'))
+        array2 = fake_array('foo', np.dtype('S3'))
+        stack = ArrayStack(np.array([array1, array2]))
+        self.assertEqual(stack.fill_value, 'foo')
+
+    def test_different_strings(self):
+        array1 = fake_array('foo', np.dtype('S3'))
+        array2 = fake_array('bar', np.dtype('S3'))
         with self.assertRaises(ValueError):
             stack = ArrayStack(np.array([array1, array2]))
 

--- a/biggus/tests/unit/test_LinearMosaic.py
+++ b/biggus/tests/unit/test_LinearMosaic.py
@@ -24,41 +24,52 @@ import numpy as np
 from biggus import LinearMosaic
 
 
-def fake_array(fill_value):
-    return mock.Mock(shape=(3, 4), dtype=mock.sentinel.DTYPE,
-                     fill_value=fill_value)
+def fake_array(fill_value, dtype=np.dtype('f4')):
+    return mock.Mock(shape=(3, 4), dtype=dtype, fill_value=fill_value)
 
 
 class Test___init___fill_values(unittest.TestCase):
     def test_nan_nan(self):
         array1 = fake_array(np.nan)
         array2 = fake_array(np.nan)
-        stack = LinearMosaic(np.array([array1, array2]), 0)
-        self.assertTrue(np.isnan(stack.fill_value))
+        mosaic = LinearMosaic(np.array([array1, array2]), 0)
+        self.assertTrue(np.isnan(mosaic.fill_value))
 
     def test_nan_number(self):
         array1 = fake_array(np.nan)
         array2 = fake_array(42)
         with self.assertRaises(ValueError):
-            stack = LinearMosaic(np.array([array1, array2]), 0)
+            mosaic = LinearMosaic(np.array([array1, array2]), 0)
 
     def test_number_nan(self):
         array1 = fake_array(42)
         array2 = fake_array(np.nan)
         with self.assertRaises(ValueError):
-            stack = LinearMosaic(np.array([array1, array2]), 0)
+            mosaic = LinearMosaic(np.array([array1, array2]), 0)
 
     def test_number_number(self):
         array1 = fake_array(42)
         array2 = fake_array(42)
-        stack = LinearMosaic(np.array([array1, array2]), 0)
-        self.assertEqual(stack.fill_value, 42)
+        mosaic = LinearMosaic(np.array([array1, array2]), 0)
+        self.assertEqual(mosaic.fill_value, 42)
 
     def test_number_other_number(self):
         array1 = fake_array(42)
         array2 = fake_array(43)
         with self.assertRaises(ValueError):
-            stack = LinearMosaic(np.array([array1, array2]), 0)
+            mosaic = LinearMosaic(np.array([array1, array2]), 0)
+
+    def test_matching_strings(self):
+        array1 = fake_array('foo', np.dtype('S3'))
+        array2 = fake_array('foo', np.dtype('S3'))
+        mosaic = LinearMosaic(np.array([array1, array2]), 0)
+        self.assertEqual(mosaic.fill_value, 'foo')
+
+    def test_different_strings(self):
+        array1 = fake_array('foo', np.dtype('S3'))
+        array2 = fake_array('bar', np.dtype('S3'))
+        with self.assertRaises(ValueError):
+            mosaic = LinearMosaic(np.array([array1, array2]), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes an [issue](https://groups.google.com/forum/#!topic/scitools-biggus/Rdhong9LLow) trying to create an ArrayStack with a string dtype.
