### PR TITLE
Mdtol for mean

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -1613,7 +1613,6 @@ def mean(a, axis=None, mdtol=1):
     :rtype: Array
 
     """
-    import pdb;pdb.set_trace()
     axes = _normalise_axis(axis, a)
     assert axes is not None and len(axes) == 1
     dtype = (np.array([0], dtype=a.dtype) / 1.).dtype


### PR DESCRIPTION
This PR adds missing data tolerance (mdtol) support to biggus.mean().
