### PR TITLE
Fix indexing of aggregations for which axis != 0.

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -1573,8 +1573,15 @@ class _Aggregation(ComputedArray):
 
     def __getitem__(self, keys):
         keys = self._normalise_keys(keys)
-        keys = (slice(None),) + keys
-        return _Aggregation(self._array[keys], self._axis,
+        # Insert an ':' into these keys to get keys for self._array.
+        keys = list(keys)
+        keys[self._axis:self._axis] = [slice(None)]
+        keys = tuple(keys)
+        # Reduce the aggregation-axis by the number of prior dimensions that
+        # get removed by the indexing operation.
+        result_axis = self._axis - sum([isinstance(key, (int, np.integer))
+                                        for key in keys[:self._axis]])
+        return _Aggregation(self._array[keys], result_axis,
                             self._streams_handler_class,
                             self._masked_streams_handler_class,
                             self.dtype,


### PR DESCRIPTION
Aggregation.__getitem__ was behaving always as if self._axis == 0 (a previous restriction).
Problem case example: 

```
>>> data = np.zeros((5,4,3))
>>> data = biggus.NumpyArrayAdapter(data)
>>> mean = biggus.mean(data, axis=1)
>>> print 'Mean:', mean
Mean: <_Aggregation shape=(5, 3) dtype=dtype('float64')>
>>> print 'Mean[0]:', mean[0]
Mean[0]: <_Aggregation shape=(5,) dtype=dtype('float64')>
```

 -- **shape should be (3,) instead of (5,)**

It was also only tested for axis==0.
Fixed that by just looping the existing test over all axes.
