### PR TITLE
Support for boolean indexing

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -687,6 +687,12 @@ class _ArrayAdapter(Array):
                 raise IndexError(msg)
         elif isinstance(key, slice):
             pass
+        elif isinstance(key, np.ndarray) and key.dtype == np.dtype('bool'):
+            if key.size > size:
+                msg = 'too many boolean indices. Boolean index array ' \
+                      'of size {0} is greater than axis {1} with ' \
+                      'size {2}'.format(key.size, axis, size)
+                raise IndexError(msg)
         elif isinstance(key, collections.Iterable) and \
                 not isinstance(key, basestring):
             # Make sure we capture the values in case we've
@@ -718,6 +724,15 @@ class _ArrayAdapter(Array):
             result_key = indices[new_key]
         elif isinstance(new_key, slice):
             result_key = indices.__getitem__(new_key)
+        elif isinstance(new_key, np.ndarray) and \
+                new_key.dtype == np.dtype('bool'):
+            # Numpy boolean indexing.
+            if new_key.size > size:
+                msg = 'too many boolean indices. Boolean index array ' \
+                      'of size {0} is greater than axis {1} with ' \
+                      'size {2}'.format(new_key.size, axis, size)
+                raise IndexError(msg)
+            result_key = tuple(np.array(indices)[new_key])
         elif isinstance(new_key, collections.Iterable) and \
                 not isinstance(new_key, basestring):
             # Make sure we capture the values in case we've
@@ -1861,6 +1876,9 @@ def _sliced_shape(shape, keys):
         elif isinstance(key, slice):
             size = len(range(*key.indices(size)))
             sliced_shape.append(size)
+        elif isinstance(key, np.ndarray) and key.dtype == np.dtype('bool'):
+            # Numpy boolean indexing.
+            sliced_shape.append(sum(key))
         elif isinstance(key, (tuple, np.ndarray)):
             sliced_shape.append(len(key))
         else:

--- a/biggus/tests/test_adapter.py
+++ b/biggus/tests/test_adapter.py
@@ -97,6 +97,33 @@ class _TestAdapter(object):
                 (2, 3, 15, 40)],
             [(21, 5, 2, 70, 30, 40), [(0, (1, 4), 1, (2, 5, 10),
                                        slice(None, 15))], (2, 3, 15, 40)],
+            # Boolean indexing
+            [(3, 4), [np.array([0, 1, 0], dtype=bool)], (1, 4)],
+            [(3, 4), [np.array([1, 0, 1], dtype=bool)], (2, 4)],
+            [(3, 4), [np.array([0, 0, 0], dtype=bool)], (0, 4)],
+            [(3, 4), [np.array([1, 1, 1], dtype=bool)], (3, 4)],
+            [(3, 4), [(slice(None), np.array([1, 0, 1, 1], dtype=bool))],
+             (3, 3)],
+            [(3, 4), [(slice(None), np.array([0, 1, 0, 0], dtype=bool))],
+             (3, 1)],
+            [(3, 4), [(slice(None), np.array([1, 1, 1, 1], dtype=bool))],
+             (3, 4)],
+            [(3, 4), [(slice(None), np.array([0, 0, 0, 0], dtype=bool))],
+             (3, 0)],
+            # Boolean indexing (too few indices - zero pad)
+            [(3, 4), [np.array([1, 1], dtype=bool)], (2, 4)],
+            [(3, 4), [(slice(None), np.array([1, 1, 1], dtype=bool))], (3, 3)],
+            # Boolean indexing (too many indices)
+            [(3, 4), [np.array([1, 1, 1, 0], dtype=bool)], IndexError],
+            [(3, 4), [(slice(None), np.array([1, 1, 1, 1, 0], dtype=bool))],
+             IndexError],
+            # Boolean testing, repeated slicing
+            [(3, 4), [(slice(None), slice(None)),
+                      np.array([0, 1, 0], dtype=bool)], (1, 4)],
+            [(3, 4), [(slice(None), slice(None)),
+                      (slice(None), slice(None)),
+                      np.array([0, 1, 1], dtype=bool),
+                      np.array([1, 0], dtype=bool)], (1, 4)],
         ]
         for src_shape, cuts, target in tests:
             array = self.zeros_adapter(src_shape)


### PR DESCRIPTION
Biggus is used in Iris. Before the switch to use Biggus one could used boolean indexing on cubes (see https://github.com/SciTools/iris/pull/643). Biggus does not currently support this ability e.g.

``` python
>>> import biggus
>>> import numpy as np
>>> a = biggus.NumpyArrayAdapter(np.arange(12).reshape(3,4))
>>> a
<NumpyArrayAdapter shape=(3, 4) dtype=dtype('int64')>
>>> a[np.array([True, False, True])]
<NumpyArrayAdapter shape=(3, 4) dtype=dtype('int64')>
```

This should be

``` python
<NumpyArrayAdapter shape=(2, 4) dtype=dtype('int64')>
```

This PR adds this functionality.
