### PR TITLE
Force object dtype to avoid unwanted iteration.

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -938,8 +938,15 @@ class ArrayStack(Array):
     """
     An Array made from a homogeneous array of other Arrays.
 
+    Parameters
+    ----------
+    stack : array-like
+        The array of Arrays to be stacked, where each Array must be of
+        the same shape.
+
     """
     def __init__(self, stack):
+        stack = np.require(stack, dtype='O')
         first_array = stack.flat[0]
         item_shape = first_array.shape
         dtype = first_array.dtype
@@ -1044,6 +1051,8 @@ class ArrayStack(Array):
             where each Array in the stack must be of the same shape.
 
         """
+        arrays = np.require(arrays, dtype='O')
+
         order = order.lower()
 
         # Ensure a suitable shape has been specified.

--- a/biggus/tests/test_save.py
+++ b/biggus/tests/test_save.py
@@ -65,7 +65,7 @@ class TestWritePattern(unittest.TestCase):
     def test_large(self):
         # Source data: 15 GB
         small_array = self._small_array()
-        array = biggus.ArrayStack(np.array([[small_array] * 1000] * 5))
+        array = biggus.ArrayStack([[small_array] * 1000] * 5)
         target = _WriteCounter(array.shape)
         biggus.save([array], [target])
         self.assertTrue(target.all_written())

--- a/biggus/tests/unit/test_ArrayStack.py
+++ b/biggus/tests/unit/test_ArrayStack.py
@@ -86,7 +86,7 @@ class Test___init___fill_values(unittest.TestCase):
 
 class Test_multidim_array_stack(unittest.TestCase):
     def setUp(self):
-        self.arrays = np.array([ConstantArray((), i) for i in range(6)])
+        self.arrays = [ConstantArray((), i) for i in range(6)]
 
     def test_stack_order_c_numpy_array_t1(self):
         # 1D stack of arrays shape (6,)
@@ -101,14 +101,6 @@ class Test_multidim_array_stack(unittest.TestCase):
         res = ArrayStack.multidim_array_stack(self.arrays, (2, 3), order='C')
         arr = np.array([i for i in range(6)])
         target = np.reshape(arr, (2, 3), order='C')
-        self.assertTrue(np.array_equal(res.ndarray(), target))
-
-    def test_stack_order_c_list(self):
-        # 1D stack of arrays length  6
-        res = ArrayStack.multidim_array_stack(self.arrays.tolist(), (3, 2),
-                                              order='C')
-        arr = np.array([i for i in range(6)])
-        target = np.reshape(arr, (3, 2), order='C')
         self.assertTrue(np.array_equal(res.ndarray(), target))
 
     def test_stack_order_c_multidim(self):
@@ -154,8 +146,7 @@ class Test_multidim_array_stack(unittest.TestCase):
 
     def test_multidim_stack_multidim(self):
         # Multidim stack of arrays shape (4, 6)
-        arrays = np.array([[ConstantArray((), i) for i in range(6)] for
-                           i in range(4)])
+        arrays = [[ConstantArray((), i) for i in range(6)] for i in range(4)]
         msg = 'multidimensional stacks not yet supported'
         with self.assertRaisesRegexp(ValueError, msg):
             ArrayStack.multidim_array_stack(arrays, (3, 2, 4))


### PR DESCRIPTION
Something changed in NumPy 1.9 which means that np.array(my_list_of_Arrays) ends up iterating on the Array objects in the list using `__getitem__`. (This can take _ages_!) Using an explicit object dtype avoids this problem.

By adding `np.require(..., 'O')` to the `ArrayStack` constructor we avoid the need for user/test code to create the ndarray themselves and reduce the chance of the problem.
