### PR TITLE
Added conda recipe building for Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,32 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-install: "pip install -r requirements.txt --use-mirrors"
-script: "python setup.py test"
+ - '2.7'
+ - '3.3'
+ - '3.4'
+
+env:
+  global:
+    - CONDA_BLD_PATH=~/builds/
+  matrix:
+    - CONDA_BUILD=true  CONDA_NPY=18
+    - CONDA_BUILD=true  CONDA_NPY=19
+    - PIP_BUILD=true
+
+  global:
+    # BINSTAR_TOKEN, created by first "binstar auth --create --name BiggusTravisCI -o SciTools" then "travis encrypt BINSTAR_TOKEN=<TOKEN>".
+    secure: bI6LYzyjZubMMx7cALrhcmfY0Af6KCo7BUBl23XLWY64+zFDwC7Od2mWnVWqKKuGMaexgSyOwoyfBTMGfvNDVF1fNiQwjD8XNquPMZdyFcLISEBdotkCl4lmrOj50VBIw4Sq5NcbbVdVsk8qMgUX9keZhESLlf2qza26NYtN+yQ=
+
+install:
+  - if [[ "${CONDA_BUILD}" ]]; then source conda.recipe/setup_conda_on_travis.sh; fi
+  - if [[ "${PIP_BUILD}" ]]; then pip install -r requirements.txt --use-mirrors; fi
+
+script:
+  # The environment variables to conda build are not preserved, so write the important ones to a file which can be read by the
+  # build script
+  - if [[ "${CONDA_BUILD}" ]]; then echo ${TRAVIS_BRANCH} > conda.recipe/travis_branch.txt; echo ${TRAVIS_TAG} > conda.recipe/travis_tag.txt; fi
+  - if [[ "${CONDA_BUILD}" ]]; then conda build ./conda.recipe; fi
+  - if [[ "${PIP_BUILD}" ]]; then python setup.py test; fi
+
+after_success:
+  # We only upload if there is a Binstar token defined. That only happens if travis-ci is running on SciTools/biggus - and not on PRs to that repo.
+  - if [[ "${CONDA_BUILD}" ]] && [[ "${BINSTAR_TOKEN}" ]]; then binstar -t ${BINSTAR_TOKEN} upload -u scitools -c dev ~/builds/*/biggus*.tar.bz2; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
  - '3.4'
 
 env:
-  global:
-    - CONDA_BLD_PATH=~/builds/
   matrix:
     - CONDA_BUILD=true  CONDA_NPY=18
     - CONDA_BUILD=true  CONDA_NPY=19
@@ -29,4 +27,4 @@ script:
 
 after_success:
   # We only upload if there is a Binstar token defined. That only happens if travis-ci is running on SciTools/biggus - and not on PRs to that repo.
-  - if [[ "${CONDA_BUILD}" ]] && [[ "${BINSTAR_TOKEN}" ]]; then binstar -t ${BINSTAR_TOKEN} upload -u scitools -c dev ~/builds/*/biggus*.tar.bz2; fi
+  - if [[ "${CONDA_BUILD}" ]] && [[ "${BINSTAR_TOKEN}" ]]; then binstar -t ${BINSTAR_TOKEN} upload -u scitools -c dev ~/miniconda/conda-bld/*/biggus*.tar.bz2; fi

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON -sE setup.py install
+
+
+export TRAVIS_TAG=$(cat ${RECIPE_DIR}/travis_tag.txt | tr -d \n)
+export TRAVIS_BRANCH=$(cat ${RECIPE_DIR}/travis_branch.txt | tr -d \n)
+
+$PYTHON -sE ${RECIPE_DIR}/version.py > __conda_version__.txt

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,18 @@
+package:
+    name: biggus
+
+source:
+    path: ../
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - numpy
+
+about:
+    home: https://pypi.python.org/pypi/Biggus
+    license: LGPL
+    summary: Virtual large arrays and lazy evaluation.

--- a/conda.recipe/setup_conda_on_travis.sh
+++ b/conda.recipe/setup_conda_on_travis.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
+
+PY_VERSION=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
+
+python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 ${PY_VERSION:0:1} --without-obvci
+source ~/miniconda/bin/activate root
+
+conda install --yes -n root python=${PY_VERSION} conda conda-build binstar jinja2 setuptools
+conda config --set show_channel_urls True

--- a/conda.recipe/setup_conda_on_travis.sh
+++ b/conda.recipe/setup_conda_on_travis.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
+wget https://raw.githubusercontent.com/pelson/Obvious-CI/v0.1.0/bootstrap-obvious-ci-and-miniconda.py
 
 PY_VERSION=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
 

--- a/conda.recipe/version.py
+++ b/conda.recipe/version.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+
+import os
+import subprocess
+import sys
+
+
+def version_str(directory, branch, SHA):
+    """
+    Get the version of biggus for a given SHA on a given branch.
+    """
+    cmd = ['git', 'log' , '--oneline', SHA]
+    commits = subprocess.check_output(cmd, cwd=directory).strip()
+    if commits:
+        n_commits = len(commits.split(b'\n'))
+    else:
+        n_commits = 0
+    return '{branch}.{n_commits}.g{SHA}'.format(branch=branch,
+                                               n_commits=n_commits,
+                                               SHA=SHA)
+
+
+def compute_version(git_directory):
+    if os.environ.get('TRAVIS_TAG', ''):
+        print('Using TRAVIS_TAG as version string.', file=sys.stderr)
+        version = os.environ['TRAVIS_TAG']
+    else:
+        if os.environ.get('TRAVIS_BRANCH', ''):
+            print('Using TRAVIS_BRANCH to compute version string.', file=sys.stderr)
+            branch = os.environ['TRAVIS_BRANCH']
+        else:
+            print('Attempting to determine the branch of the git repo - '
+                  'this is not 100% fool-proof.', file=sys.stderr)
+            cmd = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
+            branch = subprocess.check_output(cmd, cwd=git_directory).strip().decode('ascii')
+        sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).strip().decode('ascii')
+        version = version_str(git_directory, branch, sha)
+        print('Computed version as:', version, file=sys.stderr)
+
+    return version
+
+
+if __name__ == '__main__':
+    print(compute_version(os.getcwd()))


### PR DESCRIPTION
This adds automated building of a dev version of biggus to the dev channel of scitools.

It was my intention to maintain order-ability for each build, but it turned out to be a non-trivial problem (there isn't enough information in the way we manage branches to do this). Therefore, I ruled it out of scope, and instead went for the less ambitious approach of maintaining the branch name in the version. Once these builds are complete, they will have a version string along the lines of ``<name of branch>.<n commits since start of repo>.g<GIT SHA>``. For example, on master a version such as ``master.178.g9a2c919`` may occur.