### PR TITLE
Allow for scalar keys prior to the mosaic axis.

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -1224,7 +1224,13 @@ class LinearMosaic(Array):
                 if isinstance(axis_key, slice) and \
                         axis_key.step is not None and axis_key.step < 0:
                     tiles.reverse()
-                result = LinearMosaic(tiles, axis)
+                # Adjust the axis of the new mosaic to account for any
+                # scalar keys prior to our current mosaic axis.
+                new_axis = axis
+                for key in keys[:axis]:
+                    if _is_scalar(key):
+                        new_axis -= 1
+                result = LinearMosaic(tiles, new_axis)
             else:
                 raise TypeError('invalid key {!r}'.format(axis_key))
 

--- a/biggus/tests/test_linear_mosaic.py
+++ b/biggus/tests/test_linear_mosaic.py
@@ -176,6 +176,22 @@ class TestLinearMosaic(unittest.TestCase):
         with self.assertRaises(TypeError):
             result = mosaic['foo'].ndarray()
 
+    def test_getitem_adjust_axis(self):
+        tile_1 = self._tile((3, 4, 5))
+        tile_2 = self._tile((3, 4, 2))
+        mosaic = biggus.LinearMosaic([tile_1, tile_2], 2)
+        result = mosaic[1, :, :]
+        self.assertEqual(result.shape, (4, 7))
+        result = mosaic[:, 1, :]
+        self.assertEqual(result.shape, (3, 7))
+
+    def test_getitem_adjust_axis_2(self):
+        tile_1 = self._tile((3, 4, 5))
+        tile_2 = self._tile((3, 4, 2))
+        mosaic = biggus.LinearMosaic([tile_1, tile_2], 2)
+        result = mosaic[1, 1, :]
+        self.assertEqual(result.shape, (7,))
+
     def test_ndarray(self):
         tile3x4 = self._tile((3, 4))
         mosaic = biggus.LinearMosaic(tile3x4, 0)


### PR DESCRIPTION
This PR fixes a bug which occurs when a mosaic with a non-zero axis is sliced with a scalar key prior to that axis. For example:

``` python
>>> mosaic = LinearMosaic([tile1, tile2], axis=2)
>>> mosaic[0, :, :]
ValueError: invalid axis for 2-dimensional tiles
```

Bug [reported by pagw](https://groups.google.com/d/msg/scitools-iris/QLwAWxPdnRM/jWPppi8T7-gJ) on the Iris discussion group.
