### PR TITLE
Mutable transposed array axes.

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -955,7 +955,7 @@ class TransposedArray(Array):
             axes = np.arange(array.ndim)[::-1]
         elif len(axes) != array.ndim:
             raise ValueError('Incorrect number of dimensions.')
-        self.axes = axes
+        self.axes = list(axes)
         self._forward_axes_map = {src: dest for dest, src in enumerate(axes)}
         self._inverse_axes_map = {dest: src for dest, src in enumerate(axes)}
 

--- a/biggus/tests/unit/test_TransposedArray.py
+++ b/biggus/tests/unit/test_TransposedArray.py
@@ -117,10 +117,12 @@ class Test___getitem__(unittest.TestCase):
             result = self.a[:2, 0, :, 2, 1]
 
     def test_new_axis_indexing_more_than_n(self):
-        result = self.a[:2, 0, :, np.newaxis, :]
-        expected = self.arr_transposed[:2, 0, :, np.newaxis, :]
-        self.assertEqual(result.shape, (2, 5, 1, 4))
-        assert_array_equal(result.ndarray(), expected)
+        t = TransposedArray(self.orig_array, tuple(self.a.axes))
+        for array in [self.a, t]:
+            result = self.a[:2, 0, :, np.newaxis, :]
+            expected = self.arr_transposed[:2, 0, :, np.newaxis, :]
+            self.assertEqual(result.shape, (2, 5, 1, 4))
+            assert_array_equal(result.ndarray(), expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Minor tweak to prevent the following:

```python
>>> t = biggus.TransposedArray(np.empty((2, 3, 4, 5)), (1, 3, 0, 2))
>>> t[:2, 0, :, np.newaxis, :]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/h05/itwl/projects/git/biggus/biggus/__init__.py", line 1027, in __getitem__
    new_transpose_order.insert(new_axis, self.ndim + n_new_axes)
AttributeError: 'tuple' object has no attribute 'insert'
```