### PR TITLE
Fix for #121.

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -2281,14 +2281,27 @@ def _full_keys(keys, ndim):
     if not isinstance(keys, tuple):
         keys = (keys,)
 
+    # Make keys mutable, and take a copy.
+    keys = list(keys)[:]
+
+    # Count the number of keys which actually slice a dimension.
+    n_keys_non_newaxis = len([key for key in keys if key is not np.newaxis])
+
+    # Numpy allows an extra dimension to be an Ellipsis, we remove it here
+    # if Ellipsis is in keys, if this doesn't trigger we will raise an
+    # IndexError.
+    if n_keys_non_newaxis - 1 >= ndim and Ellipsis in keys:
+        # Remove the left-most Ellipsis, as numpy does.
+        keys.remove(Ellipsis)
+        n_keys_non_newaxis -= 1
+
+    if n_keys_non_newaxis > ndim:
+        raise IndexError('Dimensions are over specified for indexing.')
+
     lh_keys = []
     # Keys, with the last key first.
     rh_keys = []
 
-    lh_new_axes = 0
-    rh_new_axes = 0
-
-    keys = list(keys)[:]
     take_from_left = True
     while keys:
         if take_from_left:
@@ -2301,20 +2314,9 @@ def _full_keys(keys, ndim):
         if next_key is Ellipsis:
             next_key = slice(None)
             take_from_left = not take_from_left
-        elif next_key is np.newaxis:
-            if take_from_left:
-                lh_new_axes += 1
-            else:
-                rh_new_axes += 1
         keys_list.append(next_key)
 
-    lh_len = len(lh_keys) - lh_new_axes
-    rh_len = len(rh_keys) - rh_new_axes
-
-    if rh_len + lh_len > ndim:
-        raise IndexError('Dimensions are over specified for indexing.')
-
-    middle = [slice(None)] * (ndim - rh_len - lh_len)
+    middle = [slice(None)] * (ndim - n_keys_non_newaxis)
     return tuple(lh_keys + middle + rh_keys[::-1])
 
 

--- a/biggus/tests/unit/test__full_keys.py
+++ b/biggus/tests/unit/test__full_keys.py
@@ -73,6 +73,16 @@ class Test__full_keys(unittest.TestCase):
         self.assertFullSlice((np.newaxis, Ellipsis, None, np.newaxis), 2,
                              [None, slice(None), slice(None), None, None])
 
+    def test_redundant_ellipsis(self):
+        keys = (slice(None), Ellipsis, 0, Ellipsis, slice(None))
+        self.assertFullSlice(keys, 4,
+                             (slice(None), 0, slice(None), slice(None)))
+
+    def test_ellipsis_expands_to_nothing(self):
+        keys = (slice(None, None, -1), Ellipsis, slice(1, 2))
+        self.assertFullSlice(keys, 2,
+                             (slice(None, None, -1), slice(1, 2)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
``_full_keys`` now handles an ndim + 1 iterable of keys, provided one of them is an Ellipsis.