### PR TITLE
Tests fail on 32-bit

### DIFF
--- a/biggus/tests/unit/test_ConstantArray.py
+++ b/biggus/tests/unit/test_ConstantArray.py
@@ -72,7 +72,7 @@ class Test___init__(unittest.TestCase):
 
     def test_dtype_default_integer(self):
         array = ConstantArray((), 42)
-        self.assertEqual(array.dtype, np.dtype('i8'))
+        self.assertEqual(array.dtype, np.dtype(np.int_))
 
 
 class Test___getitem__(unittest.TestCase):


### PR DESCRIPTION
See [this example build](https://copr-be.cloud.fedoraproject.org/results/qulogic/SciTools/fedora-21-i386/python-biggus-0.8.0-1.fc21/build.log):
```
======================================================================
FAIL: test_dtype_default_integer (biggus.tests.unit.test_ConstantArray.Test___init__)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/biggus-0.8.0/biggus/tests/unit/test_ConstantArray.py", line 75, in test_dtype_default_integer
    self.assertEqual(array.dtype, np.dtype('i8'))
AssertionError: dtype('int32') != dtype('int64')
----------------------------------------------------------------------
```
though I don't seem to see anything that might have changed here.