### PR TITLE
Make str(Array)/repr(Array) more consistent.

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -490,12 +490,16 @@ class Array(object):
         return np.asarray(result, dtype=dtype)
 
     def __str__(self):
-        fmt = '<Array shape={} dtype={!r} size={}>'
-        return fmt.format(self.shape, self.dtype, size(self))
+        fmt = '<Array shape=({}) dtype={!r} size={}>'
+        return fmt.format(', '.join(str(items) for items in self.shape),
+                          self.dtype,
+                          size(self))
 
     def __repr__(self):
-        return '<{} shape={} dtype={!r}>'.format(type(self).__name__,
-                                                 self.shape, self.dtype)
+        fmt = '<{} shape=({}) dtype={!r}>'
+        return fmt.format(type(self).__name__,
+                          ', '.join(str(items) for items in self.shape),
+                          self.dtype)
 
     @property
     def fill_value(self):

--- a/biggus/tests/unit/test_Array.py
+++ b/biggus/tests/unit/test_Array.py
@@ -100,7 +100,7 @@ class Test___str__(unittest.TestCase):
 
     def test_1d(self):
         self._test(4, 'f8',
-                   "<Array shape=(4,) dtype=dtype('float64') size=32 B>")
+                   "<Array shape=(4) dtype=dtype('float64') size=32 B>")
 
     def test_nd(self):
         self._test((2, 6, 5), 'f8',
@@ -108,35 +108,35 @@ class Test___str__(unittest.TestCase):
 
     def test_1023(self):
         self._test(1023, 'i1',
-                   "<Array shape=(1023,) dtype=dtype('int8') size=1023 B>")
+                   "<Array shape=(1023) dtype=dtype('int8') size=1023 B>")
 
     def test_1024(self):
         self._test(1024, 'i1',
-                   "<Array shape=(1024,) dtype=dtype('int8') size=1.00 KiB>")
+                   "<Array shape=(1024) dtype=dtype('int8') size=1.00 KiB>")
 
     def test_40000(self):
         self._test(40000, 'i1',
-                   "<Array shape=(40000,) dtype=dtype('int8') size=39.06 KiB>")
+                   "<Array shape=(40000) dtype=dtype('int8') size=39.06 KiB>")
 
     def test_999999(self):
         self._test(
             9999999, 'i1',
-            "<Array shape=(9999999,) dtype=dtype('int8') size=9.54 MiB>")
+            "<Array shape=(9999999) dtype=dtype('int8') size=9.54 MiB>")
 
     def test_999999999(self):
         self._test(
             9999999999, 'i1',
-            "<Array shape=(9999999999,) dtype=dtype('int8') size=9.31 GiB>")
+            "<Array shape=(9999999999) dtype=dtype('int8') size=9.31 GiB>")
 
     def test_999999999999(self):
         self._test(
             9999999999999, 'i1',
-            "<Array shape=(9999999999999,) dtype=dtype('int8') size=9.09 TiB>")
+            "<Array shape=(9999999999999) dtype=dtype('int8') size=9.09 TiB>")
 
     def test_999999999999999(self):
         self._test(
             9999999999999999, 'i1',
-            "<Array shape=(9999999999999999,) dtype=dtype('int8') "
+            "<Array shape=(9999999999999999) dtype=dtype('int8') "
             "size=9094.95 TiB>")
 
 


### PR DESCRIPTION
Apparently, `str(tuple)` uses `repr()` on each element, which is troublesome for large integers, since they print as longs with an `L` suffix. This is more likely to occur in 32-bit (and on Python 2.)

Fixes #138.