### PR TITLE
Fixed bug with LinearMosaic __getitem__ and updated test coverage

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -1907,11 +1907,10 @@ class LinearMosaic(Array):
                         start = axis_indices[0]
                         step = 1
                         stop = start + 1
+                        tile_slice[axis] = slice(start, stop, step)
                     else:
-                        start = axis_indices[0]
-                        step = axis_indices[1] - start
-                        stop = axis_indices[-1] + step
-                    tile_slice[axis] = slice(start, stop, step)
+                        tile_slice[axis] = axis_indices
+
                     tiles.append(tile[tuple(tile_slice)])
                 if isinstance(axis_key, slice) and \
                         axis_key.step is not None and axis_key.step < 0:

--- a/biggus/tests/test_linear_mosaic.py
+++ b/biggus/tests/test_linear_mosaic.py
@@ -173,12 +173,12 @@ class TestLinearMosaic(unittest.TestCase):
         target = 6
         np.testing.assert_array_equal(result, target)
 
-	result = mosaic[:, (0,1,3)]
-	target = [[ 0,  1,  3],
-                  [ 4,  5,  7],
-                  [ 8,  9, 11]]
+        result = mosaic[:, (0, 1, 3)]
+        target = [[0,  1,  3],
+                  [4,  5,  7],
+                  [8,  9, 11]]
 
-	np.testing.assert_array_equal(result, target)
+        np.testing.assert_array_equal(result, target)
 
         with self.assertRaises(TypeError):
             result = mosaic['foo'].ndarray()

--- a/biggus/tests/test_linear_mosaic.py
+++ b/biggus/tests/test_linear_mosaic.py
@@ -173,6 +173,13 @@ class TestLinearMosaic(unittest.TestCase):
         target = 6
         np.testing.assert_array_equal(result, target)
 
+	result = mosaic[:, (0,1,3)]
+	target = [[ 0,  1,  3],
+                  [ 4,  5,  7],
+                  [ 8,  9, 11]]
+
+	np.testing.assert_array_equal(result, target)
+
         with self.assertRaises(TypeError):
             result = mosaic['foo'].ndarray()
 


### PR DESCRIPTION
Fixes a bug in `LinearMosaic._getitem_full_keys` which was causing incorrect output for array slicing. The test I've added illustrates the issue. This bug came up in a support ticket from an iris user attempting to extract data by season from a cube and I imagine there could be other problems that pop up in edge cases in iris when lazy data is being used because of this bug.

Specifically, the problem was that when the slicing key for the tiling axis is split up into keys for each individual tile, biggus assumes that each tile's part of the key can be represented as a slice based on the step between the first two indices in the tile and ending at the final index in the tile. This isn't always the case (see added test).

