### PR TITLE
Python 2 __div__

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -108,8 +108,6 @@ class Engine(object):
         individual arrays one by one.
 
         """
-        print('ndarray 111')
-        
         pass
 
 
@@ -465,7 +463,6 @@ class AllThreadedEngine(Engine):
         return self._evaluate(arrays, True)
 
     def ndarrays(self, *arrays):
-        print('ndarrays 468')
         return self._evaluate(arrays, False)
 
 
@@ -575,7 +572,6 @@ class Array(object):
         virtual array.
 
         """
-        print('ndarray 578')
 
     @abstractmethod
     def masked_array(self):
@@ -681,7 +677,6 @@ class ArrayContainer(Array):
 
     def ndarray(self):
     
-        print('ndarray 682')
         try:
             return self.array.ndarray()
         except AttributeError:
@@ -821,7 +816,6 @@ class NewAxesArray(ArrayContainer):
         return new_array
 
     def ndarray(self):
-        print('ndarray 822')
         array = super(NewAxesArray, self).ndarray()
         return array.__getitem__(self._newaxis_keys())
 
@@ -1069,7 +1063,6 @@ class BroadcastArray(ArrayContainer):
         return as_strided(array, shape=tuple(shape), strides=tuple(strides))
 
     def ndarray(self):
-        print('ndarray 1070')
         array = super(BroadcastArray, self).ndarray()
         return self._broadcast_numpy_array(array, self._broadcast_dict,
                                            self._leading_shape)
@@ -1116,7 +1109,6 @@ class AsDataTypeArray(ArrayContainer):
                           self.dtype)
 
     def ndarray(self):
-        print('ndarray 1117')
         return super(AsDataTypeArray,
                      self).ndarray().astype(self.dtype)
 
@@ -1175,7 +1167,6 @@ class ConstantArray(Array):
         return ConstantArray(shape, self.value, self._dtype)
 
     def ndarray(self):
-        print('ndarray 1176')
         result = np.empty(self.shape, self._dtype)
         result.fill(self.value)
         return result
@@ -1388,7 +1379,6 @@ class _ArrayAdapter(Array):
         pass
 
     def ndarray(self):
-        print('ndarray 1389')
         array = self._apply_keys()
         # We want the shape of the result to match the shape of the
         # Array, so where we've ended up with an array-scalar,
@@ -1623,7 +1613,6 @@ class TransposedArray(ArrayContainer):
         return TransposedArray(new_arr, new_transpose_order)
 
     def ndarray(self):
-        print('ndarray 1624')
         array = super(TransposedArray, self).ndarray()
         return array.transpose(self.axes)
 
@@ -1713,7 +1702,6 @@ class ArrayStack(Array):
         self._stack[keys] = value
 
     def ndarray(self):
-        print('ndarray 1714')
         data = np.empty(self.shape, dtype=self.dtype)
         for index in np.ndindex(self._stack.shape):
             data[index] = self._stack[index].ndarray()
@@ -1944,7 +1932,6 @@ class LinearMosaic(Array):
         return result
 
     def ndarray(self):
-        print('ndarray 1945')
         data = np.empty(self.shape, dtype=self.dtype)
         offset = 0
         indices = [slice(None)] * self.ndim
@@ -1979,7 +1966,6 @@ def ndarrays(arrays):
     individual arrays one by one.
 
     """
-    print('ndarrays 1980')
     return engine.ndarrays(*arrays)
 
 
@@ -2484,7 +2470,6 @@ class _Aggregation(ComputedArray):
                             self._kwargs)
 
     def ndarray(self):
-        print('ndarray 2485')
         result, = engine.ndarrays(self)
         return result
 
@@ -2794,7 +2779,6 @@ class _Elementwise(ComputedArray):
         return result
 
     def ndarray(self):
-        print('ndarray 2795')
         result = self._calc(self._numpy_op)
         return result
 

--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -108,6 +108,8 @@ class Engine(object):
         individual arrays one by one.
 
         """
+        print('ndarray 111')
+        
         pass
 
 
@@ -463,6 +465,7 @@ class AllThreadedEngine(Engine):
         return self._evaluate(arrays, True)
 
     def ndarrays(self, *arrays):
+        print('ndarrays 468')
         return self._evaluate(arrays, False)
 
 
@@ -572,6 +575,7 @@ class Array(object):
         virtual array.
 
         """
+        print('ndarray 578')
 
     @abstractmethod
     def masked_array(self):
@@ -631,9 +635,11 @@ class Array(object):
         except TypeError:
             return NotImplemented
 
-    # In Python 2 we implement "/" as floor division. When divide is imported
-    # from __future__ it is __truediv__ which is called in both Python 2 & 3.
-    __div__ = __floordiv__
+    def __div__(self, other):
+        try:
+            return divide(self, other)
+        except TypeError:
+            return NotImplemented
 
     def __truediv__(self, other):
         try:
@@ -674,6 +680,8 @@ class ArrayContainer(Array):
         return self.array.__getitem__(keys)
 
     def ndarray(self):
+    
+        print('ndarray 682')
         try:
             return self.array.ndarray()
         except AttributeError:
@@ -813,6 +821,7 @@ class NewAxesArray(ArrayContainer):
         return new_array
 
     def ndarray(self):
+        print('ndarray 822')
         array = super(NewAxesArray, self).ndarray()
         return array.__getitem__(self._newaxis_keys())
 
@@ -1060,6 +1069,7 @@ class BroadcastArray(ArrayContainer):
         return as_strided(array, shape=tuple(shape), strides=tuple(strides))
 
     def ndarray(self):
+        print('ndarray 1070')
         array = super(BroadcastArray, self).ndarray()
         return self._broadcast_numpy_array(array, self._broadcast_dict,
                                            self._leading_shape)
@@ -1106,6 +1116,7 @@ class AsDataTypeArray(ArrayContainer):
                           self.dtype)
 
     def ndarray(self):
+        print('ndarray 1117')
         return super(AsDataTypeArray,
                      self).ndarray().astype(self.dtype)
 
@@ -1164,6 +1175,7 @@ class ConstantArray(Array):
         return ConstantArray(shape, self.value, self._dtype)
 
     def ndarray(self):
+        print('ndarray 1176')
         result = np.empty(self.shape, self._dtype)
         result.fill(self.value)
         return result
@@ -1376,6 +1388,7 @@ class _ArrayAdapter(Array):
         pass
 
     def ndarray(self):
+        print('ndarray 1389')
         array = self._apply_keys()
         # We want the shape of the result to match the shape of the
         # Array, so where we've ended up with an array-scalar,
@@ -1610,6 +1623,7 @@ class TransposedArray(ArrayContainer):
         return TransposedArray(new_arr, new_transpose_order)
 
     def ndarray(self):
+        print('ndarray 1624')
         array = super(TransposedArray, self).ndarray()
         return array.transpose(self.axes)
 
@@ -1699,6 +1713,7 @@ class ArrayStack(Array):
         self._stack[keys] = value
 
     def ndarray(self):
+        print('ndarray 1714')
         data = np.empty(self.shape, dtype=self.dtype)
         for index in np.ndindex(self._stack.shape):
             data[index] = self._stack[index].ndarray()
@@ -1929,6 +1944,7 @@ class LinearMosaic(Array):
         return result
 
     def ndarray(self):
+        print('ndarray 1945')
         data = np.empty(self.shape, dtype=self.dtype)
         offset = 0
         indices = [slice(None)] * self.ndim
@@ -1963,6 +1979,7 @@ def ndarrays(arrays):
     individual arrays one by one.
 
     """
+    print('ndarrays 1980')
     return engine.ndarrays(*arrays)
 
 
@@ -2467,6 +2484,7 @@ class _Aggregation(ComputedArray):
                             self._kwargs)
 
     def ndarray(self):
+        print('ndarray 2485')
         result, = engine.ndarrays(self)
         return result
 
@@ -2776,6 +2794,7 @@ class _Elementwise(ComputedArray):
         return result
 
     def ndarray(self):
+        print('ndarray 2795')
         result = self._calc(self._numpy_op)
         return result
 
@@ -2817,10 +2836,18 @@ def multiply(a, b):
 
 def floor_divide(a, b):
     """
-    Return the elementwise evaluation of `a / b` as another Array.
+    Return the elementwise evaluation of `a // b` as another Array.
 
     """
     return _Elementwise(a, b, np.floor_divide, np.ma.floor_divide)
+
+
+def divide(a, b):
+    """
+    Return the elementwise evaluation of 'a / b' as another Array.
+
+    """
+    return _Elementwise(a, b, np.divide, np.ma.divide)
 
 
 def true_divide(a, b):
@@ -2838,6 +2865,19 @@ def power(a, b):
     """
     return _Elementwise(a, b, np.power, np.ma.power)
 
+def exp(a):
+    """
+    Return the elementwise evaluation of `exp(a)` as another Array.
+
+    """
+    return _Elementwise(np.exp(1), a, np.power, np.ma.power)
+    
+def log(a):
+    """
+    Return the elementwise evaluation of the natural `log(a)` as another Array.
+
+    """
+    return _Elementwise(a, a, np.log, np.ma.log)
 
 def _sliced_shape(shape, keys):
     """

--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -676,7 +676,6 @@ class ArrayContainer(Array):
         return self.array.__getitem__(keys)
 
     def ndarray(self):
-    
         try:
             return self.array.ndarray()
         except AttributeError:
@@ -2849,19 +2848,6 @@ def power(a, b):
     """
     return _Elementwise(a, b, np.power, np.ma.power)
 
-def exp(a):
-    """
-    Return the elementwise evaluation of `exp(a)` as another Array.
-
-    """
-    return _Elementwise(np.exp(1), a, np.power, np.ma.power)
-    
-def log(a):
-    """
-    Return the elementwise evaluation of the natural `log(a)` as another Array.
-
-    """
-    return _Elementwise(a, a, np.log, np.ma.log)
 
 def _sliced_shape(shape, keys):
     """

--- a/biggus/tests/test_elementwise.py
+++ b/biggus/tests/test_elementwise.py
@@ -87,8 +87,11 @@ class TestElementwise(unittest.TestCase):
     def test_true_divide(self):
         self._test_elementwise(biggus.true_divide, np.true_divide)
 
-    def test_true_divide(self):
+    def test_floor_divide(self):
         self._test_elementwise(biggus.floor_divide, np.floor_divide)
+
+    def test_divide(self):
+        self._test_elementwise(biggus.divide, np.divide)
 
     def test_power(self):
         self._test_elementwise(biggus.power, np.power)
@@ -98,6 +101,10 @@ class TestElementwise(unittest.TestCase):
         # and the result is as expected.
         r = biggus.add(np.arange(3) * 2, 5)
         assert_array_equal(r.ndarray(), [5, 7, 9])
+
+    def test_divide_float(self):
+        r = biggus.divide(np.arange(3.), 2.)
+        assert_array_equal(r.ndarray(), [0., 0.5, 1.])
 
     def test_true_divide_float(self):
         r = biggus.true_divide(np.arange(3.), 2.)

--- a/biggus/tests/unit/test_Array.py
+++ b/biggus/tests/unit/test_Array.py
@@ -220,13 +220,6 @@ class Test___mul__(unittest.TestCase, AssertElementwiseMixin):
 
 
 class Test___floordiv__(unittest.TestCase, AssertElementwiseMixin):
-    def test_div_is_floordiv(self):
-        # Div and floordiv implement the same interface.
-        # Python3 doesn't care about div, just floordiv and truediv.
-        if sys.version_info[0] == 2:
-            self.assertIs(biggus.Array.__floordiv__.im_func,
-                          biggus.Array.__div__.im_func)
-
     def test_other_array(self):
         a = FakeArray([2, 4])
         b = FakeArray([2, 4])
@@ -238,6 +231,20 @@ class Test___floordiv__(unittest.TestCase, AssertElementwiseMixin):
         a = FakeArray([2, 2])
         with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
             a // None
+
+
+class Test___div__(unittest.TestCase, AssertElementwiseMixin):
+    def test_other_array(self):
+        a = FakeArray([2, 4])
+        b = FakeArray([2, 4])
+        r = a / b
+        self.assertIsInstance(r, biggus._Elementwise)
+        self.assertElementwise(r, biggus.divide(a, b))
+
+    def test_other_no_good(self):
+        a = FakeArray([2, 2])
+        with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
+            a / None
 
 
 class Test___trudiv__(unittest.TestCase, AssertElementwiseMixin):

--- a/biggus/tests/unit/test_Array.py
+++ b/biggus/tests/unit/test_Array.py
@@ -25,6 +25,8 @@ import numpy as np
 import biggus
 from biggus import Array
 
+import operator
+
 
 RESULT_NDARRAY = np.arange(12).reshape(3, 4)
 
@@ -237,7 +239,7 @@ class Test___div__(unittest.TestCase, AssertElementwiseMixin):
     def test_other_array(self):
         a = FakeArray([2, 4])
         b = FakeArray([2, 4])
-        r = a / b
+        r = operator.div(a, b)
         self.assertIsInstance(r, biggus._Elementwise)
         self.assertElementwise(r, biggus.divide(a, b))
 

--- a/biggus/tests/unit/test_Array.py
+++ b/biggus/tests/unit/test_Array.py
@@ -25,8 +25,6 @@ import numpy as np
 import biggus
 from biggus import Array
 
-import operator
-
 
 RESULT_NDARRAY = np.arange(12).reshape(3, 4)
 
@@ -239,14 +237,13 @@ class Test___div__(unittest.TestCase, AssertElementwiseMixin):
     def test_other_array(self):
         a = FakeArray([2, 4])
         b = FakeArray([2, 4])
-        r = operator.div(a, b)
+        r = a.__div__(b)
         self.assertIsInstance(r, biggus._Elementwise)
         self.assertElementwise(r, biggus.divide(a, b))
 
     def test_other_no_good(self):
         a = FakeArray([2, 2])
-        with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
-            a / None
+        self.assertIs(a.__div__(None), NotImplemented)
 
 
 class Test___trudiv__(unittest.TestCase, AssertElementwiseMixin):


### PR DESCRIPTION
As discussed in #148, I have added added the necessary components for biggus to mimic Python 2 when performing division operations.

I have redefined `__div__` so that it takes into account the dtype of arguments to 'properly' evaluate when using Python 2.

Note: when using Python 3, or `__future__` division, nothing will change as Python 3 only uses `__floordiv__` and `__truediv__`

I wasn't sure about where to put a test checking that `/` evaluates to `__div__` as the unit tests for `biggus.Array` use `__future__` division. To test this would then require a new unit test file I think?

I have added a test to check that `operator.div` evaluates properly which might be all that is needed?

Any thoughts would be much appreciated!