### PR TITLE
NumPy 1.10+1.11 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+env:
+  - NUMPY="numpy==1.7"
+  - NUMPY="--upgrade numpy"
 install:
   - pip install -r requirements.txt
   - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == '2' ]]; then
       pip install mock;
     fi
+  - pip install $NUMPY
   - pip freeze
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ install:
   - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == '2' ]]; then
       pip install mock;
     fi
+  - pip freeze
 script: "python setup.py test"

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -1689,9 +1689,11 @@ class ArrayStack(Array):
         self._item_shape = item_shape
         self._dtype = dtype
         if fill_value is None:
-            self._fill_value = np.ma.empty(0, dtype=dtype).fill_value
-        else:
-            self._fill_value = fill_value
+            fill_value = np.ma.empty(0, dtype=dtype).fill_value
+            if dtype.kind == 'S':
+                # Ensure this is consistent across NumPy versions.
+                fill_value = dtype.type(fill_value)
+        self._fill_value = fill_value
 
     def __deepcopy__(self, memo):
         # We override deepcopy here as a result of
@@ -1882,9 +1884,11 @@ class LinearMosaic(Array):
         self._axis = axis
         self._cached_shape = None
         if common_fill_value is None:
-            self._fill_value = np.ma.empty(0, dtype=common_dtype).fill_value
-        else:
-            self._fill_value = common_fill_value
+            common_fill_value = np.ma.empty(0, dtype=common_dtype).fill_value
+            if common_dtype.kind == 'S':
+                # Ensure this is consistent across NumPy versions.
+                common_fill_value = common_dtype.type(common_fill_value)
+        self._fill_value = common_fill_value
 
     @property
     def dtype(self):

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -1082,7 +1082,9 @@ class BroadcastArray(ArrayContainer):
         strides = [0] * len(leading_shape) + list(array.strides)
         for broadcast_axis in broadcast_dict:
             strides[broadcast_axis + len(leading_shape)] = 0
-        return as_strided(array, shape=tuple(shape), strides=tuple(strides))
+        strided = as_strided(array, shape=tuple(shape), strides=tuple(strides))
+        strided.flags.writeable = False  # Fix bug in NumPy 1.10.1.
+        return strided
 
     def ndarray(self):
         array = super(BroadcastArray, self).ndarray()

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -2394,8 +2394,8 @@ class _StdStreamsHandler(_AggregationStreamsHandler):
 
     def bootstrap(self, processed_chunk_shape):
         self.k = 1
-        dtype = (np.zeros(1, dtype=self.array.dtype) / 1.).dtype
-        self.q = np.zeros(processed_chunk_shape, dtype=dtype)
+        self._dtype = (np.zeros(1, dtype=self.array.dtype) / 1.).dtype
+        self.q = np.zeros(processed_chunk_shape, dtype=self._dtype)
 
     def finalise(self):
         self.q /= (self.k - self.ddof)
@@ -2407,10 +2407,10 @@ class _StdStreamsHandler(_AggregationStreamsHandler):
         return chunk
 
     def process_data(self, data):
-        data = np.rollaxis(data, self.axis)
+        data = np.rollaxis(data, self.axis).astype(self._dtype)
 
         if self.k == 1:
-            self.a = data[0].copy()
+            self.a = data[0]
             data = data[1:]
 
         for data_slice in data:

--- a/biggus/tests/unit/init/test_Array.py
+++ b/biggus/tests/unit/init/test_Array.py
@@ -151,9 +151,9 @@ class Test___hash__(unittest.TestCase):
 class Test_astype(unittest.TestCase):
     def test(self):
         array = FakeArray((2, 3, 4))
-        result = array.astype('>f32')
+        result = array.astype('>f4')
         self.assertIsInstance(result, biggus._init.AsDataTypeArray)
-        self.assertEqual(result.dtype, '>f32')
+        self.assertEqual(result.dtype, '>f4')
 
 
 class Test_transpose(unittest.TestCase):

--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -83,7 +83,7 @@ class Test___init___fill_values(unittest.TestCase):
         array1 = fake_array('foo', np.dtype('S3'))
         array2 = fake_array('bar', np.dtype('S3'))
         stack = ArrayStack(np.array([array1, array2]))
-        self.assertEqual(stack.fill_value, 'N/A')
+        self.assertEqual(stack.fill_value, b'N/A')
 
 
 class Test_multidim_array_stack(unittest.TestCase):

--- a/biggus/tests/unit/init/test_AsDataTypeArray.py
+++ b/biggus/tests/unit/init/test_AsDataTypeArray.py
@@ -27,8 +27,8 @@ from biggus._init import ArrayContainer, NumpyArrayAdapter, AsDataTypeArray
 class Test___init__(unittest.TestCase):
     def test_nd_array(self):
         orig = np.arange(24)
-        array = AsDataTypeArray(orig, '>f32')
-        self.assertEqual(array.dtype, '>f32')
+        array = AsDataTypeArray(orig, '>f4')
+        self.assertEqual(array.dtype, '>f4')
         self.assertIs(array.array, orig)
 
 
@@ -41,17 +41,17 @@ class Test___getitem__(unittest.TestCase):
 class Test_ndarray(unittest.TestCase):
     def test_nd_array(self):
         orig = np.arange(3)
-        array = AsDataTypeArray(orig, '>f32')
-        assert_array_equal(array.ndarray(), np.array([0, 1, 2], dtype='>f32'))
+        array = AsDataTypeArray(orig, '>f4')
+        assert_array_equal(array.ndarray(), np.array([0, 1, 2], dtype='>f4'))
 
 
 class Test_masked_array(unittest.TestCase):
     def test_nd_array(self):
         orig = np.arange(3)
-        array = AsDataTypeArray(orig, '>f32')
+        array = AsDataTypeArray(orig, '>f4')
         self.assertIsInstance(array.masked_array(), np.ma.masked_array)
         assert_array_equal(array.masked_array(),
-                           np.array([0, 1, 2], dtype='>f32'))
+                           np.array([0, 1, 2], dtype='>f4'))
 
 
 if __name__ == '__main__':

--- a/biggus/tests/unit/init/test_LinearMosaic.py
+++ b/biggus/tests/unit/init/test_LinearMosaic.py
@@ -82,7 +82,7 @@ class Test___init___fill_values(unittest.TestCase):
         array1 = fake_array('foo', np.dtype('S3'))
         array2 = fake_array('bar', np.dtype('S3'))
         mosaic = LinearMosaic(np.array([array1, array2]), 0)
-        self.assertEqual(mosaic.fill_value, 'N/A')
+        self.assertEqual(mosaic.fill_value, b'N/A')
 
 
 class Test___getitem__(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy < 1.10
+numpy
 pep8


### PR DESCRIPTION
Some tests do not pass with [NumPy 1.10](https://copr-be.cloud.fedoraproject.org/results/qulogic/SciTools/fedora-rawhide-x86_64/00116135-python-biggus/build.log.gz). Most of these are due to invalid dtype strings, which are fixed here. There are three more failures, but they are a bit too deep into the internals for me to understand:
```python
======================================================================
ERROR: test_simple (biggus.tests.unit.test_BroadcastArray.Test_masked_array)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../biggus/tests/unit/test_BroadcastArray.py", line 125, in test_simple
    expected, _ = np.broadcast_arrays(orig.data, result)
  File ".../numpy/lib/stride_tricks.py", line 200, in broadcast_arrays
    for array in args]
  File ".../numpy/lib/stride_tricks.py", line 70, in _broadcast_to
    result.flags.writeable = True
ValueError: cannot set WRITEABLE flag to True of this array
======================================================================
ERROR: test_multi_int (biggus.tests.unit.test_std_var.TestNumpyArrayAdapter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../biggus/tests/unit/test_std_var.py", line 102, in test_multi_int
    self._check(self.data, shape=(3, 4), ddof=ddof)
  File ".../biggus/tests/unit/test_std_var.py", line 90, in _check
    result = bfunc(array, axis=0, ddof=ddof).ndarray()
  File ".../biggus/__init__.py", line 2471, in ndarray
    result, = engine.ndarrays(self)
  File ".../biggus/__init__.py", line 466, in ndarrays
    return self._evaluate(arrays, False)
  File ".../biggus/__init__.py", line 457, in _evaluate
    ndarrays = group.evaluate(masked)
  File ".../biggus/__init__.py", line 443, in evaluate
    raise Exception('error during evaluation')
Exception: error during evaluation
======================================================================
ERROR: test_all_masked (biggus.tests.unit.test_sum.TestNumpyArrayAdapterMasked)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../biggus/tests/unit/_aggregation_test_framework.py", line 142, in test_all_masked
    self._check(data)
  File ".../biggus/tests/unit/_aggregation_test_framework.py", line 109, in _check
    result = self.biggus_operator(array, axis=0).masked_array()
  File ".../biggus/__init__.py", line 2475, in masked_array
    result, = engine.masked_arrays(self)
  File ".../biggus/__init__.py", line 463, in masked_arrays
    return self._evaluate(arrays, True)
  File ".../biggus/__init__.py", line 457, in _evaluate
    ndarrays = group.evaluate(masked)
  File ".../biggus/__init__.py", line 443, in evaluate
    raise Exception('error during evaluation')
Exception: error during evaluation
```
Any idea for fixing up these last three would be appreciated.