### PR TITLE
[BUG] indexing an _Elementwise

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -2883,7 +2883,7 @@ class _Elementwise(ComputedArray):
 
     def _getitem_full_keys(self, keys):
         if self._array2 is None:
-            result = _Elementwise(self._array1[keys],
+            result = _Elementwise(self._array1[keys], None,
                                   self._numpy_op, self._ma_op)
         else:
             result = _Elementwise(self._array1[keys], self._array2[keys],

--- a/biggus/tests/unit/test__Elementwise.py
+++ b/biggus/tests/unit/test__Elementwise.py
@@ -112,5 +112,12 @@ class Test_single_argument_dtype(unittest.TestCase):
         self.assertEqual(actual.ndarray().max(), 4)
 
 
+class Test_single_argument(unittest.TestCase):
+    def test_getitem(self):
+        a1 = np.arange(3)
+        actual = Elementwise(a1, None, np.cos)
+        self.assertEqual(actual[1].ndarray(), np.cos(a1[1]))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes an oversight with indexing a single array instance of `_Elementwise` - the second array was not being accounted for so a NumPy `ufunc` was being passed to `_Elementwise` where it was expecting a Biggus array.