### PR TITLE
Set a constant chunk size

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -2097,7 +2097,7 @@ def _all_slices_inner(shape, always_slices=False):
                 slices = range(size)
         # Otherwise we have found the dimension that reaches the MAX_CHUNK_SIZE
         # limit, so we apply a range which gives chunk sizes as close to the
-        # MAX_CHUNK_SIZE as possible. 
+        # MAX_CHUNK_SIZE as possible.
         else:
             step = MAX_CHUNK_SIZE // n_elems
             slices = []

--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -199,8 +199,7 @@ class ProducerNode(Node):
             # we have to transpose `all_cuts` and `cut_shape` ourselves.
             # Then we have to invert the transposition once we have
             # indentified the relevant slices.
-            all_cuts = _all_slices_inner(self.array.dtype.itemsize,
-                                         self.array.shape,
+            all_cuts = _all_slices_inner(self.array.shape,
                                          always_slices=True)
             all_cuts = [all_cuts[i] for i in self.iteration_order]
             cut_shape = tuple(len(cuts) for cuts in all_cuts)
@@ -2055,24 +2054,31 @@ def masked_arrays(arrays):
     return engine.masked_arrays(*arrays)
 
 
-#: The maximum number of bytes to allow when processing an array in
-#: "bite-size" chunks. The value has been empirically determined to
+#: The maximum number of bytes per chunk to allow when processing an array in
+#: "bite-size" chunks. Chunks are determined by the _all_slices function, where
+#: an assumption is made that data type nbytes is 8.
+#: The value has been empirically determined to
 #: provide vaguely near optimal performance under certain conditions.
-MAX_CHUNK_SIZE = 8 * 1024 * 1024
+MAX_CHUNK_SIZE = 8 * 1024 * 1024 * 2
 
 
 def _all_slices(array):
-    return _all_slices_inner(array.dtype.itemsize, array.shape)
+    return _all_slices_inner(array.shape)
 
 
-def _all_slices_inner(item_size, shape, always_slices=False):
+def _all_slices_inner(shape, always_slices=False):
     # Return the slices for each dimension which ensure complete
     # coverage by chunks no larger than MAX_CHUNK_SIZE.
     # e.g. For a float32 array of shape (100, 768, 1024) the slices are:
     #   (0, 1, 2, ..., 99),
     #   (slice(0, 256), slice(256, 512), slice(512, 768)),
     #   (slice(None)
-    nbytes = item_size
+
+    # Fix the item size to 8 bytes, as this is part of the definition of
+    # MAX_CHUNK_SIZE. nbytes will be updated as we traverse the dimensions of
+    # shape so that it equals the number of bytes that one item in the current
+    # dimension represents.
+    nbytes = 8
     all_slices = []
     # We walk through the dimensions, starting from the RHS,
     # and keep track of the total size of one item in the current dimension
@@ -2092,7 +2098,7 @@ def _all_slices_inner(item_size, shape, always_slices=False):
                 slices = range(size)
         # Otherwise we have found the dimension that reaches the MAX_CHUNK_SIZE
         # limit, so we apply a range which gives chunk sizes as close to the
-        #  MAX_CHUNK_SIZE as possible. 
+        # MAX_CHUNK_SIZE as possible. 
         else:
             step = MAX_CHUNK_SIZE // nbytes
             slices = []

--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -2074,14 +2074,25 @@ def _all_slices_inner(item_size, shape, always_slices=False):
     #   (slice(None)
     nbytes = item_size
     all_slices = []
+    # We walk through the dimensions, starting from the RHS,
+    # and keep track of the total size of one item in the current dimension
+    # in the nbytes variable.
     for i, size in reversed(list(enumerate(shape))):
+        # Check to see if the whole of this dimension can fit into a single
+        # chunk.
         if size * nbytes <= MAX_CHUNK_SIZE:
             slices = (slice(None),)
+        # Otherwise, determine if previous dimensions have already saturated
+        # MAX_CHUNK_SIZE. If so, we need to pick off each item from this
+        # dimension.
         elif nbytes > MAX_CHUNK_SIZE:
             if always_slices:
                 slices = [slice(i, i + 1) for i in range(size)]
             else:
                 slices = range(size)
+        # Otherwise we have found the dimension that reaches the MAX_CHUNK_SIZE
+        # limit, so we apply a range which gives chunk sizes as close to the
+        #  MAX_CHUNK_SIZE as possible. 
         else:
             step = MAX_CHUNK_SIZE // nbytes
             slices = []

--- a/biggus/tests/__init__.py
+++ b/biggus/tests/__init__.py
@@ -1,9 +1,30 @@
-import numpy as np
+# (C) British Crown Copyright 2014 - 2015, Met Office
+#
+# This file is part of Biggus.
+#
+# Biggus is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Biggus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import contextmanager
 
 try:
     from unittest import mock
 except ImportError:
     import mock
+
+import numpy as np
+
+import biggus
 
 
 class AccessCounter(object):
@@ -46,3 +67,11 @@ class _KeyGen(object):
 
 #: An object that can be indexed to return a usable key.
 key_gen = _KeyGen()
+
+
+@contextmanager
+def set_chunk_size(value):
+    old_chunk_size = biggus.MAX_CHUNK_SIZE
+    biggus.MAX_CHUNK_SIZE = value
+    yield
+    biggus.MAX_CHUNK_SIZE = old_chunk_size

--- a/biggus/tests/integration/test_aggregation.py
+++ b/biggus/tests/integration/test_aggregation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2015, Met Office
 #
 # This file is part of Biggus.
 #
@@ -21,6 +21,7 @@ import unittest
 import numpy as np
 
 import biggus
+from biggus.tests import set_chunk_size
 
 
 class Test(unittest.TestCase):
@@ -32,6 +33,17 @@ class Test(unittest.TestCase):
         self.assertEqual(result.shape, (10, 720))
         self.assertTrue(np.all(result == 0))
         self.assertTrue(np.all(result.mask == 0))
+
+
+class TestAggregation__large_array_mixed_dtypes(unittest.TestCase):
+    def test(self):
+        shape = (3, 5, 10)
+        a = biggus.ConstantArray(shape, dtype=np.float32)
+        b = biggus.ConstantArray(shape, dtype=np.float64)
+
+        with set_chunk_size(32/8*10-1):
+            result = biggus.sum(a * b, axis=0).ndarray()
+            self.assertEqual(result.shape, shape[1:])
 
 
 if __name__ == '__main__':

--- a/biggus/tests/integration/test_aggregation.py
+++ b/biggus/tests/integration/test_aggregation.py
@@ -35,7 +35,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.all(result.mask == 0))
 
 
-class TestAggregation__large_array_mixed_dtypes(unittest.TestCase):
+class TestAggregation__mixed_dtypes(unittest.TestCase):
     def test(self):
         shape = (3, 5, 10)
         a = biggus.ConstantArray(shape, dtype=np.float32)
@@ -44,6 +44,90 @@ class TestAggregation__large_array_mixed_dtypes(unittest.TestCase):
         with set_chunk_size(32/8*10-1):
             result = biggus.sum(a * b, axis=0).ndarray()
             self.assertEqual(result.shape, shape[1:])
+
+
+class Test__slices_with_mathematical_filter(unittest.TestCase):
+
+    def setUp(self):
+        self.dtype = np.float32
+
+    def _biggus_filter(self, data, weights):
+        # Filter a data array (time, <other dimensions>) using information in
+        # weights dictionary.
+        #
+        # Args:
+        #
+        # * data:
+        #     biggus array of the data to be filtered
+        # * weights:
+        #     dictionary of absolute record offset : weight
+
+        # Build filter_matrix (time to time' mapping).
+        shape = data.shape
+
+        # Build filter matrix as a numpy array and then populate.
+        filter_matrix_np = np.zeros((shape[0], shape[0])).astype(self.dtype)
+
+        for offset, value in weights.iteritems():
+            filter_matrix_np += np.diag([value] * (shape[0] - offset),
+                                        k=offset)
+            if offset > 0:
+                filter_matrix_np += np.diag([value] * (shape[0] - offset),
+                                            k=-offset)
+
+        # Create biggus array for filter matrix, adding in other dimensions.
+        for _ in shape[1:]:
+            filter_matrix_np = filter_matrix_np[..., np.newaxis]
+
+        filter_matrix_bg_single = biggus.NumpyArrayAdapter(filter_matrix_np)
+
+        # Broadcast to correct shape (time, time', lat, lon).
+        filter_matrix_bg = biggus.BroadcastArray(
+            filter_matrix_bg_single, {i+2: j for i, j in enumerate(shape[1:])})
+
+        # Broadcast filter to same shape.
+        biggus_data_for_filter = biggus.BroadcastArray(data[np.newaxis, ...],
+                                                       {0: shape[0]})
+
+        # Multiply two arrays together and sum over second time dimension.
+        filtered_data = biggus.sum(biggus_data_for_filter * filter_matrix_bg,
+                                   axis=1)
+
+        # Cut off records at start and end of output array where the filter
+        # cannot be fully applied.
+        filter_halfwidth = len(weights) - 1
+        filtered_data = filtered_data[filter_halfwidth:-filter_halfwidth]
+
+        return filtered_data
+
+    def test__biggus_filter(self):
+        shape = (1451, 1, 1)
+
+        # Generate dummy data as biggus array.
+        numpy_data = np.random.random(shape).astype(self.dtype)
+        biggus_data = biggus.NumpyArrayAdapter(numpy_data)
+
+        # Information for filter...
+        # Dictionary of weights: key = offset (absolute value), value = weight
+        weights = {0: 0.4, 1: 0.2, 2: 0.1}
+        # This is equivalent to a weights array of [0.1, 0.2, 0.4, 0.2, 0.1].
+        filter_halfwidth = len(weights) - 1
+
+        # Filter data
+        filtered_biggus_data = self._biggus_filter(biggus_data, weights)
+
+        # Extract eddy component (original data - filtered data).
+        eddy_biggus_data = (biggus_data[filter_halfwidth:-filter_halfwidth] -
+                            filtered_biggus_data)
+
+        # Aggregate over time dimension.
+        mean_eddy_biggus_data = biggus.mean(eddy_biggus_data, axis=0)
+
+        # Force evaluation.
+        mean_eddy_numpy_data = mean_eddy_biggus_data.ndarray()
+
+        # Confirm correct shape.
+        self.assertEqual(mean_eddy_numpy_data.shape, shape[1:])
 
 
 if __name__ == '__main__':

--- a/biggus/tests/integration/test_aggregation.py
+++ b/biggus/tests/integration/test_aggregation.py
@@ -41,7 +41,7 @@ class TestAggregation__mixed_dtypes(unittest.TestCase):
         a = biggus.ConstantArray(shape, dtype=np.float32)
         b = biggus.ConstantArray(shape, dtype=np.float64)
 
-        with set_chunk_size(32/8*10-1):
+        with set_chunk_size(32//8*10-1):
             result = biggus.sum(a * b, axis=0).ndarray()
             self.assertEqual(result.shape, shape[1:])
 
@@ -68,7 +68,7 @@ class Test__slices_with_mathematical_filter(unittest.TestCase):
         # Build filter matrix as a numpy array and then populate.
         filter_matrix_np = np.zeros((shape[0], shape[0])).astype(self.dtype)
 
-        for offset, value in weights.iteritems():
+        for offset, value in weights.items():
             filter_matrix_np += np.diag([value] * (shape[0] - offset),
                                         k=offset)
             if offset > 0:

--- a/biggus/tests/unit/test__all_slices.py
+++ b/biggus/tests/unit/test__all_slices.py
@@ -31,7 +31,7 @@ class Test__all_slices(unittest.TestCase):
         array = biggus.ConstantArray((4, 3, 5), dtype=np.float32)
         # Chunk size set to fit in two items from the second dimension into a
         # single chunk, but not the whole dimension.
-        chunk_size = 8 * 5 * 3 - 1
+        chunk_size = 5 * 3 - 1
         with set_chunk_size(chunk_size):
             slices = _all_slices(array)
         expected = [[0, 1, 2, 3],
@@ -41,7 +41,7 @@ class Test__all_slices(unittest.TestCase):
 
     def test_always_slices(self):
         array = biggus.ConstantArray((3, 5), dtype=np.float32)
-        chunk_size = 8 * 5 - 1
+        chunk_size = 5 - 1
         with set_chunk_size(chunk_size):
             slices = _all_slices_inner(array.shape, always_slices=True)
         expected = [[slice(0, 1, None), slice(1, 2, None), slice(2, 3, None)],

--- a/biggus/tests/unit/test__all_slices.py
+++ b/biggus/tests/unit/test__all_slices.py
@@ -16,28 +16,46 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._all_slices`."""
 
+from contextlib import contextmanager
 import unittest
 
 import numpy as np
 
 import biggus
-from biggus import _all_slices
+from biggus import _all_slices, _all_slices_inner
 from biggus.tests import mock
 
 
 class Test__all_slices(unittest.TestCase):
-    def _small_array(self):
-        shape = (5, 928, 744)
-        data = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
-        array = biggus.NumpyArrayAdapter(data)
-        return array
+    @contextmanager
+    def set_chunk_size(self, value):
+        old_chunk_size = biggus.MAX_CHUNK_SIZE
+        biggus.MAX_CHUNK_SIZE = value
+        yield
+        biggus.MAX_CHUNK_SIZE = old_chunk_size
 
-    def test_min(self):
-        array = self._small_array()
-        slices = _all_slices(array)
-        expected = [[slice(0, 3, None), slice(3, 5, None)],
-                    (slice(None, None, None),), (slice(None, None, None),)]
+    def test_all_cases(self):
+        array = biggus.ConstantArray((4, 3, 5), dtype=np.float32)
+        # Chunk size set to fit in two items from the second dimension into a
+        # single chunk, but not the whole dimension.
+        chunk_size = (32 / 8) * 5 * 3 - 1
+        with self.set_chunk_size(chunk_size):
+            slices = _all_slices(array)
+        expected = [[0, 1, 2, 3],
+                    [slice(0, 2, None), slice(2, 3, None)],
+                    (slice(None, None, None),)]
         self.assertEqual(slices, expected)
+
+    def test_always_slices(self):
+        array = biggus.ConstantArray((3, 5), dtype=np.float32)
+        chunk_size = (32 / 8) * 5 - 1
+        with self.set_chunk_size(chunk_size):
+            slices = _all_slices_inner(array.dtype.itemsize, array.shape,
+                                       always_slices=True)
+        expected = [[slice(0, 1, None), slice(1, 2, None), slice(2, 3, None)],
+                    [slice(0, 4, None), slice(4, 5, None)]]
+        self.assertEqual(slices, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Removes cleverness in setting variable (bytes and size-based) chunk sizes in favour of fixing a chunk size of 8 bytes. This works around a problem where performing operations on arrays with differing dtypes causes a broadcasting error because the chunks end up having differing sizes.

Also improves the `_all_slices` tests and documentation because these changes flowed from confirming that the right approach was being followed to make this change.

Closes #161 and fixes #164.  