### PR TITLE
Preserve mask through math operations

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -2043,6 +2043,18 @@ def ndarrays(arrays):
     return engine.ndarrays(*arrays)
 
 
+def masked_arrays(arrays):
+    """
+    Return a list of NumPy masked array objects corresponding to the given
+    biggus Array objects.
+
+    This can be more efficient (and hence faster) than converting the
+    individual arrays one by one.
+
+    """
+    return engine.masked_arrays(*arrays)
+
+
 #: The maximum number of bytes to allow when processing an array in
 #: "bite-size" chunks. The value has been empirically determined to
 #: provide vaguely near optimal performance under certain conditions.
@@ -2890,20 +2902,17 @@ class _Elementwise(ComputedArray):
                                   self._numpy_op, self._ma_op)
         return result
 
-    def _calc(self, op):
-        np_operands = ndarrays(self.sources)
-        result = op(*np_operands)
-        return result
-
     def ndarray(self):
-        result = self._calc(self._numpy_op)
+        np_operands = ndarrays(self.sources)
+        result = self._numpy_op(*np_operands)
         return result
 
     def masked_array(self):
         if self._ma_op is None:
             raise TypeError('No {} operation defined for masked arrays.'
                             ''.format(self._numpy_op.__name__))
-        result = self._calc(self._ma_op)
+        ma_operands = masked_arrays(self.sources)
+        result = self._ma_op(*ma_operands)
         return result
 
     def streams_handler(self, masked):

--- a/biggus/tests/unit/test__Elementwise.py
+++ b/biggus/tests/unit/test__Elementwise.py
@@ -29,17 +29,24 @@ from biggus import _Elementwise as Elementwise
 
 class Test__masked_arrays(unittest.TestCase):
     def setUp(self):
-        a = np.arange(6).reshape(3, 2)
+        a = np.arange(6).reshape(3, 2) - 3
         self.mask = a % 3 == 0
         self.masked_array = np.ma.masked_array(a, self.mask)
 
     def test_single_argument_operation(self):
+        expected = np.abs(self.masked_array)
         actual = Elementwise(self.masked_array, None, np.abs, ma.abs)
-        assert_array_equal(actual.masked_array().mask, self.mask)
+        result = actual.masked_array()
+        assert_array_equal(result.mask, self.mask)
+        assert_array_equal(result, expected)
 
     def test_dual_argument_operation(self):
-        actual = Elementwise(self.masked_array, 2, np.power, ma.power)
-        assert_array_equal(actual.masked_array().mask, self.mask)
+        exponent = 2
+        expected = self.masked_array ** exponent
+        actual = Elementwise(self.masked_array, exponent, np.power, ma.power)
+        result = actual.masked_array()
+        assert_array_equal(result.mask, self.mask)
+        assert_array_equal(result, expected)
 
     def test_no_masked_array_function(self):
         result = Elementwise(self.masked_array, None, np.sign)

--- a/biggus/tests/unit/test__Elementwise.py
+++ b/biggus/tests/unit/test__Elementwise.py
@@ -27,9 +27,22 @@ from numpy.testing import assert_array_equal
 from biggus import _Elementwise as Elementwise
 
 
-class Test_no_masked_array_function(unittest.TestCase):
-    def test(self):
-        result = Elementwise(np.arange(3), None, np.sign)
+class Test__masked_arrays(unittest.TestCase):
+    def setUp(self):
+        a = np.arange(6).reshape(3, 2)
+        self.mask = a % 3 == 0
+        self.masked_array = np.ma.masked_array(a, self.mask)
+
+    def test_single_argument_operation(self):
+        actual = Elementwise(self.masked_array, None, np.abs, ma.abs)
+        assert_array_equal(actual.masked_array().mask, self.mask)
+
+    def test_dual_argument_operation(self):
+        actual = Elementwise(self.masked_array, 2, np.power, ma.power)
+        assert_array_equal(actual.masked_array().mask, self.mask)
+
+    def test_no_masked_array_function(self):
+        result = Elementwise(self.masked_array, None, np.sign)
         msg = 'No sign operation defined for masked arrays'
         with self.assertRaisesRegexp(TypeError, msg):
             result.masked_array()


### PR DESCRIPTION
Ensure masked arrays are handled correctly (i.e. the mask is preserved) when performing mathematical operations using biggus operation functions such as `biggus.log10` or `biggus.power`.

Fixes #166.