### PR TITLE
doc: Fix build with Sphinx 1.3 and its napoleon extension.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,6 +13,8 @@
 
 import sys, os
 
+import sphinx
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -25,9 +27,11 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx',
-              'sphinxcontrib.napoleon']
-              #'sphinx.ext.napoleon']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
+if hasattr(sphinx, 'version_info') and sphinx.version_info[:2] >= (1, 3):
+    extensions += ['sphinx.ext.napoleon']
+else:
+    extensions += ['sphinxcontrib.napoleon']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
With Sphinx 1.3, the napoleon extension is builtin and can be found as `sphinx.ext.napoleon` instead of `sphinxcontrib.napoleon`.