### PR TITLE
BUG: Failing type return on masked array on LHS

### DIFF
--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -701,6 +701,10 @@ class ArrayContainer(Array):
         except AttributeError:
             return np.array(self.array)
 
+    @property
+    def __array_priority__(self):
+        return self.array.__array_priority__
+
     def masked_array(self):
         try:
             return self.array.masked_array()
@@ -1321,6 +1325,10 @@ class _ArrayAdapter(Array):
     @property
     def shape(self):
         return _sliced_shape(self.concrete.shape, self._keys)
+
+    @property
+    def __array_priority__(self):
+        return self.concrete.__array_priority__
 
     def _cleanup_new_key(self, key, size, axis):
         """

--- a/biggus/tests/test_integration.py
+++ b/biggus/tests/test_integration.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
 
+import mock
 import unittest
 
 import numpy as np
@@ -61,6 +62,13 @@ class TestChaining(unittest.TestCase):
 
         np.testing.assert_array_equal(result, target)
         np.testing.assert_array_equal(result.mask, target.mask)
+
+    def test_no_array_priority_attribute_present(self):
+        arr = biggus.ConstantArray((3), 1.0)
+        barr = biggus.NumpyArrayAdapter(arr)
+        result = np.array([[1.]]) * barr
+        target = np.array([[1.]]) * arr
+        np.testing.assert_array_equal(result, target)
 
 
 if __name__ == '__main__':

--- a/biggus/tests/test_integration.py
+++ b/biggus/tests/test_integration.py
@@ -49,6 +49,19 @@ class TestChaining(unittest.TestCase):
         result = mean2.ndarray()
         np.testing.assert_array_equal(result, expected)
 
+    def test_masked_array_numpy_first_biggus_second(self):
+        # Ensure that an operation where the biggus array is second (i.e.
+        # calling the special method of the numpy array not the biggus array,
+        # returns the expected type).
+        mask = [False, True, False]
+        arr = np.ma.array([1, 2, 3], mask=mask)
+        barr = biggus.NumpyArrayAdapter(arr)
+        result = (np.array([[1.]]) * barr).masked_array()
+        target = np.array([[1.]]) * arr
+
+        np.testing.assert_array_equal(result, target)
+        np.testing.assert_array_equal(result.mask, target.mask)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Self contained unittest which I have added and shown to **fail** (demonstrating what I believe to be a bug).  Essentially, the mask is thrown away.

``` Python
>>> arr = np.ma.array([1, 2, 3], mask=[False, True, False])
>>> barr = biggus.NumpyArrayAdapter(arr)
>>> print np.array([[ 1.]]) * barr
[[  1.00000000e+00   9.99999000e+05   3.00000000e+00]]
>>> print np.array([[ 1.]]) * arr
[[1.0 -- 3.0]]
```

I suspect it's because its the `__mul__` from the masked numpy array that is being called and for whatever reason, it doesn't think the biggus array is masked.
