### PR TITLE
Re-add ArrayContainer to public API

### DIFF
--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -674,6 +674,7 @@ class Array(object):
 #            return NotImplemented
 
 
+@export
 class ArrayContainer(Array):
     "A biggus.Array which passes calls through to the contained array."
     def __init__(self, contained_array):


### PR DESCRIPTION
This is a useful class for users to be able to base their own subclasses on, without having to implement the boilerplate code which is needed when sub-classing `Array`