### PR TITLE
Python 3 source compatibility

### DIFF
--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -50,6 +50,9 @@ For example::
     mean_error = mean_error.ndarray()
 
 """
+
+from __future__ import absolute_import
+
 from ._init import *
 
 

--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -52,6 +52,7 @@ For example::
 """
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from ._init import *
 

--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -51,7 +51,7 @@ For example::
 
 """
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from ._init import *
 

--- a/biggus/__init__.py
+++ b/biggus/__init__.py
@@ -51,7 +51,7 @@ For example::
 
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 from ._init import *
 

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -1213,7 +1213,7 @@ class ConstantArray(Array):
 
     """
     def __init__(self, shape, value=0.0, dtype=None):
-        if isinstance(shape, basestring):
+        if isinstance(shape, six.string_types):
             shape = (shape,)
         else:
             try:
@@ -1349,7 +1349,7 @@ class _ArrayAdapter(Array):
                       'size {2}'.format(key.size, axis, size)
                 raise IndexError(msg)
         elif isinstance(key, collections.Iterable) and \
-                not isinstance(key, basestring):
+                not isinstance(key, six.string_types):
             # Make sure we capture the values in case we've
             # been given a one-shot iterable, like a generator.
             key = tuple(key)
@@ -1389,7 +1389,7 @@ class _ArrayAdapter(Array):
                 raise IndexError(msg)
             result_key = tuple(np.array(indices)[new_key])
         elif isinstance(new_key, collections.Iterable) and \
-                not isinstance(new_key, basestring):
+                not isinstance(new_key, six.string_types):
             # Make sure we capture the values in case we've
             # been given a one-shot iterable, like a generator.
             new_key = tuple(new_key)
@@ -1990,7 +1990,7 @@ class LinearMosaic(Array):
                 tile_indices[axis] -= offsets[tile_index]
                 result = tile[tuple(tile_indices)]
             elif isinstance(axis_key, (slice, collections.Iterable)) and \
-                    not isinstance(axis_key, basestring):
+                    not isinstance(axis_key, six.string_types):
                 # Find the list of relevant tiles.
                 # NB. If the stride is large enough, this might not be a
                 # contiguous subset of self._tiles.
@@ -2635,7 +2635,7 @@ def _normalise_axis(axis, array):
     elif _is_scalar(axis):
         axes = (axis,)
     elif (isinstance(axis, collections.Iterable) and
-            not isinstance(axis, (basestring, collections.Mapping)) and
+            not isinstance(axis, (six.string_types, collections.Mapping)) and
             all(map(_is_scalar, axis))):
         axes = tuple(axis)
     else:

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -19,12 +19,12 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 from abc import ABCMeta, abstractproperty, abstractmethod
-import __builtin__
+from six.moves import builtins
 import collections
 import functools
 import itertools
 import threading
-import Queue
+from six.moves import queue
 import sys
 import warnings
 
@@ -217,11 +217,11 @@ class ConsumerNode(Node):
         """
         Set the given nodes as inputs for this node.
 
-        Creates a limited-size Queue.Queue for each input node and
+        Creates a limited-size queue.Queue for each input node and
         registers each queue as an output of its corresponding node.
 
         """
-        self.input_queues = [Queue.Queue(maxsize=3) for _ in input_nodes]
+        self.input_queues = [queue.Queue(maxsize=3) for _ in input_nodes]
         for input_node, input_queue in zip(input_nodes, self.input_queues):
             input_node.add_output_queue(input_queue)
 
@@ -2596,7 +2596,7 @@ class _Aggregation(ComputedArray):
         # Reduce the aggregation-axis by the number of prior dimensions that
         # get removed by the indexing operation.
         scalar_axes = map(_is_scalar, keys[:self._axis])
-        result_axis = self._axis - __builtin__.sum(scalar_axes)
+        result_axis = self._axis - builtins.sum(scalar_axes)
         return _Aggregation(self._array[keys], result_axis,
                             self._streams_handler_class,
                             self._masked_streams_handler_class,
@@ -3163,7 +3163,7 @@ def _sliced_shape(shape, keys):
             sliced_shape.append(size)
         elif isinstance(key, np.ndarray) and key.dtype == np.dtype('bool'):
             # Numpy boolean indexing.
-            sliced_shape.append(__builtin__.sum(key))
+            sliced_shape.append(builtins.sum(key))
         elif isinstance(key, (tuple, np.ndarray)):
             sliced_shape.append(len(key))
         elif key is np.newaxis:

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -56,13 +56,11 @@ class AxisSupportError(Exception):
     """Raised when the operation is not supported over a given axis/axes."""
 
 
-class Engine(object):
+class Engine(six.with_metaclass(ABCMeta, object)):
     """
     Represents a way to evaluate lazy expressions.
 
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def masked_arrays(self, *arrays):
@@ -96,10 +94,8 @@ QUEUE_FINISHED = None
 QUEUE_ABORT = Exception
 
 
-class Node(object):
+class Node(six.with_metaclass(ABCMeta, object)):
     """A node of an expression evaluation graph."""
-
-    __metaclass__ = ABCMeta
 
     def __init__(self):
         self.output_queues = []
@@ -445,13 +441,12 @@ class AllThreadedEngine(Engine):
 
 
 @export
-class Array(object):
+class Array(six.with_metaclass(ABCMeta, object)):
     """
     A virtual array which can be sliced to create smaller virtual
     arrays, or converted to a NumPy ndarray.
 
     """
-    __metaclass__ = ABCMeta
 
     __hash__ = None
 
@@ -2179,9 +2174,7 @@ def save(sources, targets, masked=False):
             target[keys] = array[keys].ndarray()
 
 
-class _StreamsHandler(object):
-    __metaclass__ = ABCMeta
-
+class _StreamsHandler(six.with_metaclass(ABCMeta, object)):
     @abstractmethod
     def finalise(self):
         """

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from abc import ABCMeta, abstractproperty, abstractmethod
 import __builtin__

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -50,7 +50,7 @@ def _is_scalar(key):
 
 
 @export
-class AxisSupportError(StandardError):
+class AxisSupportError(Exception):
     """Raised when the operation is not supported over a given axis/axes."""
 
 

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import division
+from __future__ import absolute_import, division
 
 from abc import ABCMeta, abstractproperty, abstractmethod
 import __builtin__

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -16,6 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from abc import ABCMeta, abstractproperty, abstractmethod
 import __builtin__
@@ -408,7 +409,7 @@ class AllThreadedEngine(Engine):
                 result_nodes.append(result_node)
 
             # Start up all the producer/computation threads.
-            for node in self._node_cache.itervalues():
+            for node in six.itervalues(self._node_cache):
                 node.thread()
 
             # Wait for the result threads to finish.

--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from abc import ABCMeta, abstractproperty, abstractmethod
 import __builtin__
@@ -399,7 +400,7 @@ class AllThreadedEngine(Engine):
             result_nodes = []
             result_threads = []
             for array in self.arrays:
-                iteration_order = range(array.ndim)
+                iteration_order = list(range(array.ndim))
                 node = self._make_node(array, iteration_order, masked)
                 result_node = NdarrayNode(array, masked)
                 result_node.add_input_nodes([node])
@@ -422,7 +423,7 @@ class AllThreadedEngine(Engine):
     def _groups(self, arrays):
         # XXX Placeholder implementation which assumes everything
         # is compatible and can be evaluated in parallel.
-        return [self.Group(arrays, range(len(arrays)))]
+        return [self.Group(arrays, list(range(len(arrays))))]
 
     def _evaluate(self, arrays, masked):
         # Figure out which arrays should be evaluated in parallel.
@@ -1511,7 +1512,7 @@ class NumpyArrayAdapter(_ArrayAdapter):
                 for i, key in tuple_keys:
                     cut_keys[i] = slice(None)
                 array = self.concrete[tuple(cut_keys)]
-                is_scalar = map(_is_scalar, cut_keys)
+                is_scalar = list(map(_is_scalar, cut_keys))
                 dimensions -= np.cumsum(is_scalar)
             else:
                 # Use ellipsis indexing to ensure we have a real ndarray
@@ -1563,7 +1564,7 @@ def _pairwise(iterable):
     """
     a, b = itertools.tee(iterable)
     next(b, None)
-    return itertools.izip(a, b)
+    return zip(a, b)
 
 
 def _groups_of(length, total_length):
@@ -1973,7 +1974,7 @@ class LinearMosaic(Array):
             # then it's safe to just pass the keys to each tile.
             tile = self._tiles[0]
             tiles = [tile[keys] for tile in self._tiles]
-            scalar_keys = filter(_is_scalar, keys)
+            scalar_keys = list(filter(_is_scalar, keys))
             result = LinearMosaic(tiles, axis - len(scalar_keys))
         else:
             axis_lengths = [tile.shape[axis] for tile in self._tiles]
@@ -1998,7 +1999,7 @@ class LinearMosaic(Array):
                 else:
                     all_axis_indices = tuple(axis_key)
                 tile_indices = np.searchsorted(splits, all_axis_indices) - 1
-                pairs = itertools.izip(all_axis_indices, tile_indices)
+                pairs = zip(all_axis_indices, tile_indices)
                 i = itertools.groupby(pairs, lambda axis_tile: axis_tile[1])
                 tiles = []
                 tile_slice = list(keys)
@@ -2126,7 +2127,7 @@ def _all_slices_inner(shape, always_slices=False):
             if always_slices:
                 slices = [slice(i, i + 1) for i in range(size)]
             else:
-                slices = range(size)
+                slices = list(range(size))
         # Otherwise we have found the dimension that reaches the MAX_CHUNK_SIZE
         # limit, so we apply a range which gives chunk sizes as close to the
         # MAX_CHUNK_SIZE as possible.

--- a/biggus/tests/__init__.py
+++ b/biggus/tests/__init__.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from contextlib import contextmanager
 

--- a/biggus/tests/__init__.py
+++ b/biggus/tests/__init__.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from contextlib import contextmanager
 

--- a/biggus/tests/__init__.py
+++ b/biggus/tests/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
 
 from contextlib import contextmanager
 

--- a/biggus/tests/__init__.py
+++ b/biggus/tests/__init__.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 from contextlib import contextmanager
 

--- a/biggus/tests/integration/__init__.py
+++ b/biggus/tests/integration/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,3 +15,5 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for biggus."""
+
+from __future__ import absolute_import

--- a/biggus/tests/integration/__init__.py
+++ b/biggus/tests/integration/__init__.py
@@ -16,4 +16,4 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for biggus."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division

--- a/biggus/tests/integration/__init__.py
+++ b/biggus/tests/integration/__init__.py
@@ -17,3 +17,4 @@
 """Integration tests for biggus."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/biggus/tests/integration/__init__.py
+++ b/biggus/tests/integration/__init__.py
@@ -16,4 +16,4 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for biggus."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function

--- a/biggus/tests/integration/test_aggregation.py
+++ b/biggus/tests/integration/test_aggregation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for aggregations."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/integration/test_aggregation.py
+++ b/biggus/tests/integration/test_aggregation.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for aggregations."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/integration/test_aggregation.py
+++ b/biggus/tests/integration/test_aggregation.py
@@ -17,6 +17,7 @@
 """Integration tests for aggregations."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/integration/test_aggregation.py
+++ b/biggus/tests/integration/test_aggregation.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for aggregations."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/integration/test_engine.py
+++ b/biggus/tests/integration/test_engine.py
@@ -17,6 +17,7 @@
 """Integration tests for swappable engine."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/integration/test_engine.py
+++ b/biggus/tests/integration/test_engine.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for swappable engine."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/integration/test_engine.py
+++ b/biggus/tests/integration/test_engine.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for swappable engine."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/integration/test_engine.py
+++ b/biggus/tests/integration/test_engine.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for swappable engine."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/integration/test_maths.py
+++ b/biggus/tests/integration/test_maths.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for maths operations."""
 
+from __future__ import absolute_import
+
 import numpy as np
 import numpy.ma as ma
 import unittest

--- a/biggus/tests/integration/test_maths.py
+++ b/biggus/tests/integration/test_maths.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for maths operations."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/integration/test_maths.py
+++ b/biggus/tests/integration/test_maths.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for maths operations."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/integration/test_maths.py
+++ b/biggus/tests/integration/test_maths.py
@@ -17,6 +17,7 @@
 """Integration tests for maths operations."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/test_adapter.py
+++ b/biggus/tests/test_adapter.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/test_adapter.py
+++ b/biggus/tests/test_adapter.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2012 - 2013, Met Office
+# (C) British Crown Copyright 2012 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/test_adapter.py
+++ b/biggus/tests/test_adapter.py
@@ -177,7 +177,7 @@ class _TestAdapter(object):
         return self.wrap(ndarray, keys)
 
     def arange_adapter(self, shape, keys):
-        size = reduce(lambda x, y: x * y, shape)
+        size = np.product(shape)
         ndarray = np.arange(size).reshape(shape)
         return self.wrap(ndarray, keys)
 

--- a/biggus/tests/test_adapter.py
+++ b/biggus/tests/test_adapter.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_adapter.py
+++ b/biggus/tests/test_adapter.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/test_aggregation.py
+++ b/biggus/tests/test_aggregation.py
@@ -16,6 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import unittest
 
@@ -95,7 +96,7 @@ class TestAggregation(unittest.TestCase):
         # Check that the Aggregation raises a TypeError
         # if neither an Array or np.ndarray is given
         msg = "list' object has no attribute 'ndim"
-        with self.assertRaisesRegexp(AttributeError, msg):
+        with six.assertRaisesRegex(self, AttributeError, msg):
             biggus.mean([0, 1, 2, 3, 4], axis=0)
 
 

--- a/biggus/tests/test_aggregation.py
+++ b/biggus/tests/test_aggregation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/test_aggregation.py
+++ b/biggus/tests/test_aggregation.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 
@@ -95,7 +96,7 @@ class TestAggregation(unittest.TestCase):
         # if neither an Array or np.ndarray is given
         msg = "list' object has no attribute 'ndim"
         with self.assertRaisesRegexp(AttributeError, msg):
-            biggus.mean(range(10), axis=0)
+            biggus.mean([0, 1, 2, 3, 4], axis=0)
 
 
 class TestMdtol(unittest.TestCase):

--- a/biggus/tests/test_aggregation.py
+++ b/biggus/tests/test_aggregation.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_aggregation.py
+++ b/biggus/tests/test_aggregation.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/test_array.py
+++ b/biggus/tests/test_array.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/test_array.py
+++ b/biggus/tests/test_array.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2012, Met Office
+# (C) British Crown Copyright 2012 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
 import unittest
 
 import biggus

--- a/biggus/tests/test_array.py
+++ b/biggus/tests/test_array.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_array.py
+++ b/biggus/tests/test_array.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/test_elementwise.py
+++ b/biggus/tests/test_elementwise.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 
@@ -124,7 +125,7 @@ class TestElementwise(unittest.TestCase):
         # Check that the ElementWise functionality raises a TypeError
         # if neither an Array or np.ndarray is given
         with self.assertRaises(TypeError):
-            biggus.add(range(12), np.arange(12))
+            biggus.add(list(range(12)), np.arange(12))
 
 
 if __name__ == '__main__':

--- a/biggus/tests/test_elementwise.py
+++ b/biggus/tests/test_elementwise.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_elementwise.py
+++ b/biggus/tests/test_elementwise.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/test_elementwise.py
+++ b/biggus/tests/test_elementwise.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/test_integration.py
+++ b/biggus/tests/test_integration.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/test_integration.py
+++ b/biggus/tests/test_integration.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/test_integration.py
+++ b/biggus/tests/test_integration.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_integration.py
+++ b/biggus/tests/test_integration.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/test_linear_mosaic.py
+++ b/biggus/tests/test_linear_mosaic.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/test_linear_mosaic.py
+++ b/biggus/tests/test_linear_mosaic.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/test_linear_mosaic.py
+++ b/biggus/tests/test_linear_mosaic.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_linear_mosaic.py
+++ b/biggus/tests/test_linear_mosaic.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/test_ndarray.py
+++ b/biggus/tests/test_ndarray.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/test_ndarray.py
+++ b/biggus/tests/test_ndarray.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/test_ndarray.py
+++ b/biggus/tests/test_ndarray.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_ndarray.py
+++ b/biggus/tests/test_ndarray.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/test_pep8.py
+++ b/biggus/tests/test_pep8.py
@@ -19,6 +19,7 @@ Perform a PEP8 conformance test of the Biggus code base.
 
 """
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import os
 import unittest

--- a/biggus/tests/test_pep8.py
+++ b/biggus/tests/test_pep8.py
@@ -18,7 +18,7 @@
 Perform a PEP8 conformance test of the Biggus code base.
 
 """
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/biggus/tests/test_pep8.py
+++ b/biggus/tests/test_pep8.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -18,6 +18,8 @@
 Perform a PEP8 conformance test of the Biggus code base.
 
 """
+from __future__ import absolute_import
+
 import os
 import unittest
 

--- a/biggus/tests/test_pep8.py
+++ b/biggus/tests/test_pep8.py
@@ -18,7 +18,7 @@
 Perform a PEP8 conformance test of the Biggus code base.
 
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import os
 import unittest

--- a/biggus/tests/test_save.py
+++ b/biggus/tests/test_save.py
@@ -20,6 +20,7 @@ Unit tests for `biggus.save()`.
 """
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/test_save.py
+++ b/biggus/tests/test_save.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -18,6 +18,8 @@
 Unit tests for `biggus.save()`.
 
 """
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/test_save.py
+++ b/biggus/tests/test_save.py
@@ -19,7 +19,7 @@ Unit tests for `biggus.save()`.
 
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/test_save.py
+++ b/biggus/tests/test_save.py
@@ -19,7 +19,7 @@ Unit tests for `biggus.save()`.
 
 """
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_stack.py
+++ b/biggus/tests/test_stack.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/test_stack.py
+++ b/biggus/tests/test_stack.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2012 - 2015, Met Office
+# (C) British Crown Copyright 2012 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/test_stack.py
+++ b/biggus/tests/test_stack.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/test_stack.py
+++ b/biggus/tests/test_stack.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/__init__.py
+++ b/biggus/tests/unit/__init__.py
@@ -17,3 +17,4 @@
 """Unit tests for biggus."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/biggus/tests/unit/__init__.py
+++ b/biggus/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,3 +15,5 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for biggus."""
+
+from __future__ import absolute_import

--- a/biggus/tests/unit/__init__.py
+++ b/biggus/tests/unit/__init__.py
@@ -16,4 +16,4 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for biggus."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function

--- a/biggus/tests/unit/__init__.py
+++ b/biggus/tests/unit/__init__.py
@@ -16,4 +16,4 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for biggus."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division

--- a/biggus/tests/unit/init/__init__.py
+++ b/biggus/tests/unit/init/__init__.py
@@ -16,4 +16,4 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init`"""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function

--- a/biggus/tests/unit/init/__init__.py
+++ b/biggus/tests/unit/init/__init__.py
@@ -16,4 +16,4 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init`"""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division

--- a/biggus/tests/unit/init/__init__.py
+++ b/biggus/tests/unit/init/__init__.py
@@ -17,3 +17,4 @@
 """Unit tests for `biggus._init`"""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/biggus/tests/unit/init/__init__.py
+++ b/biggus/tests/unit/init/__init__.py
@@ -15,3 +15,5 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init`"""
+
+from __future__ import absolute_import

--- a/biggus/tests/unit/init/_aggregation_test_framework.py
+++ b/biggus/tests/unit/init/_aggregation_test_framework.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus` aggregation operators."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from abc import ABCMeta, abstractproperty
 

--- a/biggus/tests/unit/init/_aggregation_test_framework.py
+++ b/biggus/tests/unit/init/_aggregation_test_framework.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus` aggregation operators."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 from abc import ABCMeta, abstractproperty
 

--- a/biggus/tests/unit/init/_aggregation_test_framework.py
+++ b/biggus/tests/unit/init/_aggregation_test_framework.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus` aggregation operators."""
+
+from __future__ import absolute_import
+
 from abc import ABCMeta, abstractproperty
 
 import numpy as np

--- a/biggus/tests/unit/init/_aggregation_test_framework.py
+++ b/biggus/tests/unit/init/_aggregation_test_framework.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus` aggregation operators."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from abc import ABCMeta, abstractproperty
 

--- a/biggus/tests/unit/init/_aggregation_test_framework.py
+++ b/biggus/tests/unit/init/_aggregation_test_framework.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from abc import ABCMeta, abstractproperty
 
@@ -27,9 +28,7 @@ import numpy.ma as ma
 import biggus
 
 
-class Operator(object):
-    __metaclass__ = ABCMeta
-
+class Operator(six.with_metaclass(ABCMeta, object)):
     @abstractproperty
     def biggus_operator(self):
         pass

--- a/biggus/tests/unit/init/test_Array.py
+++ b/biggus/tests/unit/init/test_Array.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init.Array`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import sys
 import unittest

--- a/biggus/tests/unit/init/test_Array.py
+++ b/biggus/tests/unit/init/test_Array.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.Array`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import sys
 import unittest

--- a/biggus/tests/unit/init/test_Array.py
+++ b/biggus/tests/unit/init/test_Array.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import sys
 import unittest
@@ -190,7 +191,8 @@ class Test___add__(unittest.TestCase, AssertElementwiseMixin):
 
     def test_other_no_good(self):
         a = FakeArray([2, 2])
-        with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'unsupported operand type'):
             a + None
 
     def test___radd__(self):
@@ -210,7 +212,8 @@ class Test___sub__(unittest.TestCase, AssertElementwiseMixin):
 
     def test_other_no_good(self):
         a = FakeArray([2, 2])
-        with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'unsupported operand type'):
             a - None
 
     def test___rsub__(self):
@@ -230,7 +233,8 @@ class Test___mul__(unittest.TestCase, AssertElementwiseMixin):
 
     def test_other_no_good(self):
         a = FakeArray([2, 2])
-        with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'unsupported operand type'):
             a * None
 
     def test___rmul__(self):
@@ -250,7 +254,8 @@ class Test___floordiv__(unittest.TestCase, AssertElementwiseMixin):
 
     def test_other_no_good(self):
         a = FakeArray([2, 2])
-        with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'unsupported operand type'):
             a // None
 
     def test___rfloordiv__(self):
@@ -291,7 +296,8 @@ class Test___trudiv__(unittest.TestCase, AssertElementwiseMixin):
 
     def test_other_no_good(self):
         a = FakeArray([2, 2])
-        with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'unsupported operand type'):
             a / None
 
     def test___rtrudiv__(self):
@@ -311,7 +317,8 @@ class Test___pow__(unittest.TestCase, AssertElementwiseMixin):
 
     def test_other_no_good(self):
         a = FakeArray([2, 2])
-        with self.assertRaisesRegexp(TypeError, 'unsupported operand type'):
+        with six.assertRaisesRegex(self, TypeError,
+                                   'unsupported operand type'):
             a ** None
 
     def test___rpow__(self):

--- a/biggus/tests/unit/init/test_Array.py
+++ b/biggus/tests/unit/init/test_Array.py
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.Array`."""
-from __future__ import division
+
+from __future__ import absolute_import, division
 
 import sys
 import unittest

--- a/biggus/tests/unit/init/test_ArrayContainer.py
+++ b/biggus/tests/unit/init/test_ArrayContainer.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init.ArrayContainer`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ArrayContainer.py
+++ b/biggus/tests/unit/init/test_ArrayContainer.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.ArrayContainer`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ArrayContainer.py
+++ b/biggus/tests/unit/init/test_ArrayContainer.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.ArrayContainer`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ArrayContainer.py
+++ b/biggus/tests/unit/init/test_ArrayContainer.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.ArrayContainer`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import copy
 import unittest
@@ -36,7 +37,7 @@ class Test___init___invalid(unittest.TestCase):
             fill_value = 9
             shape = ()
         bad_arrays = np.array([BadArray()])
-        with self.assertRaisesRegexp(ValueError, 'subclass'):
+        with six.assertRaisesRegex(self, ValueError, 'subclass'):
             ArrayStack(bad_arrays)
 
 
@@ -146,21 +147,21 @@ class Test_multidim_array_stack(unittest.TestCase):
         # 1D stack of arrays shape (6,)
         # Specifying a stack shape that is not feasible.
         msg = 'total size of new array must be unchanged'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             ArrayStack.multidim_array_stack(self.arrays, (3, 1), order='C')
 
     def test_multidim_stack_multidim(self):
         # Multidim stack of arrays shape (4, 6)
         arrays = [[ConstantArray((), i) for i in range(6)] for i in range(4)]
         msg = 'multidimensional stacks not yet supported'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             ArrayStack.multidim_array_stack(arrays, (3, 2, 4))
 
     def test_order_incorrect_order(self):
         # Specifying an unknown order.
         array1 = fake_array(0)
         array2 = fake_array(0)
-        with self.assertRaisesRegexp(TypeError, 'order not understood'):
+        with six.assertRaisesRegex(self, TypeError, 'order not understood'):
             ArrayStack.multidim_array_stack([array1, array2], (1, 2),
                                             order='random')
 

--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ArrayStack`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import copy
 import unittest

--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ArrayStack`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import copy
 import unittest

--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ArrayStack`."""
+
+from __future__ import absolute_import
 
 import copy
 import unittest

--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.ArrayStack`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import copy
 import unittest
@@ -95,7 +96,7 @@ class Test_multidim_array_stack(unittest.TestCase):
     def test_stack_order_c_numpy_array_t1(self):
         # 1D stack of arrays shape (6,)
         res = ArrayStack.multidim_array_stack(self.arrays, (3, 2), order='C')
-        arr = np.array([i for i in range(6)])
+        arr = np.arange(6)
         target = np.reshape(arr, (3, 2), order='C')
         self.assertTrue(np.array_equal(res.ndarray(), target))
 
@@ -103,7 +104,7 @@ class Test_multidim_array_stack(unittest.TestCase):
         # 1D stack of arrays shape (6,)
         # alternate shape
         res = ArrayStack.multidim_array_stack(self.arrays, (2, 3), order='C')
-        arr = np.array([i for i in range(6)])
+        arr = np.arange(6)
         target = np.reshape(arr, (2, 3), order='C')
         self.assertTrue(np.array_equal(res.ndarray(), target))
 
@@ -120,7 +121,7 @@ class Test_multidim_array_stack(unittest.TestCase):
         # 1D stack of arrays shape (6,)
         # Ensure that the default index ordering corresponds to C.
         res = ArrayStack.multidim_array_stack(self.arrays, (3, 2))
-        arr = np.array([i for i in range(6)])
+        arr = np.arange(6)
         target = np.reshape(arr, (3, 2), order='C')
         self.assertTrue(np.array_equal(res.ndarray(), target))
 
@@ -128,7 +129,7 @@ class Test_multidim_array_stack(unittest.TestCase):
         # Fortran index ordering
         # 1D stack of arrays shape (6,)
         res = ArrayStack.multidim_array_stack(self.arrays, (3, 2), order='F')
-        arr = np.array([i for i in range(6)])
+        arr = np.arange(6)
         target = np.reshape(arr, (3, 2), order='F')
         self.assertTrue(np.array_equal(res.ndarray(), target))
 
@@ -137,7 +138,7 @@ class Test_multidim_array_stack(unittest.TestCase):
         # 1D stack of arrays shape (6,)
         # alternate shape
         res = ArrayStack.multidim_array_stack(self.arrays, (2, 3), order='F')
-        arr = np.array([i for i in range(6)])
+        arr = np.arange(6)
         target = np.reshape(arr, (2, 3), order='F')
         self.assertTrue(np.array_equal(res.ndarray(), target))
 

--- a/biggus/tests/unit/init/test_AsDataTypeArray.py
+++ b/biggus/tests/unit/init/test_AsDataTypeArray.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init.AsDataTypeArray`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_AsDataTypeArray.py
+++ b/biggus/tests/unit/init/test_AsDataTypeArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.AsDataTypeArray`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_AsDataTypeArray.py
+++ b/biggus/tests/unit/init/test_AsDataTypeArray.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.AsDataTypeArray`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/unit/init/test_AsDataTypeArray.py
+++ b/biggus/tests/unit/init/test_AsDataTypeArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.AsDataTypeArray`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_BroadcastArray.py
+++ b/biggus/tests/unit/init/test_BroadcastArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._ArrayAdapter`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_BroadcastArray.py
+++ b/biggus/tests/unit/init/test_BroadcastArray.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._ArrayAdapter`."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/unit/init/test_BroadcastArray.py
+++ b/biggus/tests/unit/init/test_BroadcastArray.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._ArrayAdapter`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_BroadcastArray.py
+++ b/biggus/tests/unit/init/test_BroadcastArray.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import unittest
 
@@ -37,17 +38,17 @@ class Test___init__(unittest.TestCase):
 
     def test_invalid_broadcast_axis(self):
         msg = 'Axis -1 out of range \[0, 5\)'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             BroadcastArray(np.empty([1, 3, 1, 5, 1]), {-1: 10})
 
     def test_invalid_broadcast_length(self):
         msg = 'Axis length must be positive. Got -1.'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             BroadcastArray(np.empty([1, 3, 1, 5, 1]), {0: -1})
 
     def test_broadcasting_existing_non_len1_dimension(self):
         msg = 'Attempted to broadcast axis 0 which is of length 3.'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             BroadcastArray(np.empty([3]), {0: 5})
 
     def test_nested_broadcast_avoidance(self):
@@ -66,7 +67,7 @@ class Test___init__(unittest.TestCase):
 
     def test_invalid_leading_shape(self):
         msg = 'Leading shape must all be >=1'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             BroadcastArray(np.empty([1]), {}, (-1,))
 
 
@@ -224,7 +225,7 @@ class Test_compute_broadcast_dicts(unittest.TestCase):
     def test_rule3_value_error(self):
         msg = ('operands could not be broadcast together with shapes '
                '\(2\,3\) \(1\,2\,4\)')
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             BroadcastArray._compute_broadcast_kwargs([2, 3], [1, 2, 4])
 
 

--- a/biggus/tests/unit/init/test_BroadcastArray.py
+++ b/biggus/tests/unit/init/test_BroadcastArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._ArrayAdapter`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ConstantArray.py
+++ b/biggus/tests/unit/init/test_ConstantArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ConstantArray`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ConstantArray.py
+++ b/biggus/tests/unit/init/test_ConstantArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ConstantArray`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ConstantArray.py
+++ b/biggus/tests/unit/init/test_ConstantArray.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ConstantArray`."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ConstantArray.py
+++ b/biggus/tests/unit/init/test_ConstantArray.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.ConstantArray`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_LinearMosaic.py
+++ b/biggus/tests/unit/init/test_LinearMosaic.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.LinearMosaic`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_LinearMosaic.py
+++ b/biggus/tests/unit/init/test_LinearMosaic.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.LinearMosaic`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_LinearMosaic.py
+++ b/biggus/tests/unit/init/test_LinearMosaic.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.LinearMosaic`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_LinearMosaic.py
+++ b/biggus/tests/unit/init/test_LinearMosaic.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.LinearMosaic`."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/unit/init/test_LinearMosaic.py
+++ b/biggus/tests/unit/init/test_LinearMosaic.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import unittest
 
@@ -35,7 +36,7 @@ class Test___init___invalid(unittest.TestCase):
             ndim = 1
             shape = (4,)
         bad_arrays = [BadArray()]
-        with self.assertRaisesRegexp(ValueError, 'subclass'):
+        with six.assertRaisesRegex(self, ValueError, 'subclass'):
             LinearMosaic(bad_arrays, 0)
 
 

--- a/biggus/tests/unit/init/test_NewAxesArray.py
+++ b/biggus/tests/unit/init/test_NewAxesArray.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.NewAxesArray`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/unit/init/test_NewAxesArray.py
+++ b/biggus/tests/unit/init/test_NewAxesArray.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init.NewAxesArray`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_NewAxesArray.py
+++ b/biggus/tests/unit/init/test_NewAxesArray.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import unittest
 
@@ -31,25 +32,25 @@ class Test___init__(unittest.TestCase):
     def test_too_few_axes(self):
         in_arr = ConstantArray([3, 2])
         msg = 'must have length 3 but was actually length 2'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             array = NewAxesArray(in_arr, [1, 2])
 
     def test_too_many_axes(self):
         in_arr = ConstantArray([3, 2])
         msg = 'must have length 3 but was actually length 4'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             array = NewAxesArray(in_arr, [1, 2, 0, 1])
 
     def test_new_axes_wrong_dtype(self):
         in_arr = ConstantArray([3, 2])
         msg = 'Only positive integer types may be used for new_axes.'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             array = NewAxesArray(in_arr, [1.1, 1, 1])
 
     def test_new_axes_negative(self):
         in_arr = ConstantArray([1, 2])
         msg = 'Only positive integer types may be used for new_axes.'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             array = NewAxesArray(in_arr, [-1, 0, 1])
 
     def test_successful_attribute(self):
@@ -191,7 +192,7 @@ class Test___getitem__(unittest.TestCase):
 
     def test_new_axis_numpy_array_indexing(self):
         msg = "NewAxesArray indexing not yet supported for ndarray keys."
-        with self.assertRaisesRegexp(NotImplementedError, msg):
+        with six.assertRaisesRegex(self, NotImplementedError, msg):
             self.array_3d[np.array([0, 0, 0]), ...]
 
 

--- a/biggus/tests/unit/init/test_NewAxesArray.py
+++ b/biggus/tests/unit/init/test_NewAxesArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.NewAxesArray`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_NewAxesArray.py
+++ b/biggus/tests/unit/init/test_NewAxesArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.NewAxesArray`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_NumpyArrayAdapter.py
+++ b/biggus/tests/unit/init/test_NumpyArrayAdapter.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.NumpyArrayAdapter`."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/unit/init/test_NumpyArrayAdapter.py
+++ b/biggus/tests/unit/init/test_NumpyArrayAdapter.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init.NumpyArrayAdapter`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_NumpyArrayAdapter.py
+++ b/biggus/tests/unit/init/test_NumpyArrayAdapter.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.NumpyArrayAdapter`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_NumpyArrayAdapter.py
+++ b/biggus/tests/unit/init/test_NumpyArrayAdapter.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.NumpyArrayAdapter`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_TransposedArray.py
+++ b/biggus/tests/unit/init/test_TransposedArray.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init.TransposedArray`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_TransposedArray.py
+++ b/biggus/tests/unit/init/test_TransposedArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.TransposedArray`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_TransposedArray.py
+++ b/biggus/tests/unit/init/test_TransposedArray.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import unittest
 
@@ -34,7 +35,7 @@ class Test__apply_axes_mapping(unittest.TestCase):
 
     def test_too_few_dims(self):
         msg = 'length 3, but should be of length 4'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             self.a._apply_axes_mapping(list('abc'))
 
     def test_correct_n_dims(self):
@@ -47,7 +48,7 @@ class Test__apply_axes_mapping(unittest.TestCase):
 
     def test_too_many_dims(self):
         msg = 'length 5, but should be of length 4'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             self.a._apply_axes_mapping(list('abcde'))
 
 

--- a/biggus/tests/unit/init/test_TransposedArray.py
+++ b/biggus/tests/unit/init/test_TransposedArray.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.TransposedArray`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_TransposedArray.py
+++ b/biggus/tests/unit/init/test_TransposedArray.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init.TransposedArray`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/unit/init/test__ArrayAdapter.py
+++ b/biggus/tests/unit/init/test__ArrayAdapter.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._ArrayAdapter`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test__ArrayAdapter.py
+++ b/biggus/tests/unit/init/test__ArrayAdapter.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init._ArrayAdapter`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test__ArrayAdapter.py
+++ b/biggus/tests/unit/init/test__ArrayAdapter.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._ArrayAdapter`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test__ArrayAdapter.py
+++ b/biggus/tests/unit/init/test__ArrayAdapter.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._ArrayAdapter`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 from biggus._init import _ArrayAdapter

--- a/biggus/tests/unit/init/test__Elementwise.py
+++ b/biggus/tests/unit/init/test__Elementwise.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._Elementwise`."""
 
+from __future__ import absolute_import
+
 from itertools import permutations
 from functools import partial
 import unittest

--- a/biggus/tests/unit/init/test__Elementwise.py
+++ b/biggus/tests/unit/init/test__Elementwise.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._Elementwise`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from itertools import permutations
 from functools import partial

--- a/biggus/tests/unit/init/test__Elementwise.py
+++ b/biggus/tests/unit/init/test__Elementwise.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 from itertools import permutations
 from functools import partial
@@ -54,7 +55,7 @@ class Test__masked_arrays(unittest.TestCase):
     def test_no_masked_array_function(self):
         result = Elementwise(self.masked_array, None, np.sign)
         msg = 'No sign operation defined for masked arrays'
-        with self.assertRaisesRegexp(TypeError, msg):
+        with six.assertRaisesRegex(self, TypeError, msg):
             result.masked_array()
 
 

--- a/biggus/tests/unit/init/test__Elementwise.py
+++ b/biggus/tests/unit/init/test__Elementwise.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._Elementwise`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from itertools import permutations
 from functools import partial

--- a/biggus/tests/unit/init/test__Elementwise.py
+++ b/biggus/tests/unit/init/test__Elementwise.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._Elementwise`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 from itertools import permutations
 from functools import partial

--- a/biggus/tests/unit/init/test__all_slices.py
+++ b/biggus/tests/unit/init/test__all_slices.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._all_slices`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test__all_slices.py
+++ b/biggus/tests/unit/init/test__all_slices.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._all_slices`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test__all_slices.py
+++ b/biggus/tests/unit/init/test__all_slices.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init._all_slices`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test__all_slices.py
+++ b/biggus/tests/unit/init/test__all_slices.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._all_slices`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
@@ -20,7 +20,7 @@ has wrapped.
 
 """
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import unittest

--- a/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
@@ -20,7 +20,7 @@ has wrapped.
 
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import inspect
 import unittest

--- a/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -19,6 +19,8 @@ Unit tests for `_dual_input_fn_wrapper` and the functions that it
 has wrapped.
 
 """
+
+from __future__ import absolute_import
 
 import inspect
 import unittest

--- a/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
@@ -21,6 +21,7 @@ has wrapped.
 """
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import inspect
 import unittest

--- a/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__dual_input_fn_wrapper.py
@@ -22,6 +22,7 @@ has wrapped.
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import inspect
 import unittest
@@ -83,7 +84,7 @@ class Test__dual_input_fn_wrapper(unittest.TestCase):
                                             fn_name='identity')
         msg = 'No <lambda> operation defined for masked arrays.'
         result = wrapped_fn(np.array([-5, 2]), np.array([-5, 2]))
-        with self.assertRaisesRegexp(TypeError, msg):
+        with six.assertRaisesRegex(self, TypeError, msg):
             assert_array_equal(result.masked_array(), [0, 4])
 
 

--- a/biggus/tests/unit/init/test__full_keys.py
+++ b/biggus/tests/unit/init/test__full_keys.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._full_keys`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/unit/init/test__full_keys.py
+++ b/biggus/tests/unit/init/test__full_keys.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._full_keys`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test__full_keys.py
+++ b/biggus/tests/unit/init/test__full_keys.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._full_keys`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test__full_keys.py
+++ b/biggus/tests/unit/init/test__full_keys.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._full_keys`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test__normalise_axis.py
+++ b/biggus/tests/unit/init/test__normalise_axis.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._normalise_axis`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test__normalise_axis.py
+++ b/biggus/tests/unit/init/test__normalise_axis.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._normalise_axis`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 from biggus._init import _normalise_axis

--- a/biggus/tests/unit/init/test__normalise_axis.py
+++ b/biggus/tests/unit/init/test__normalise_axis.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init._normalise_axis`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test__normalise_axis.py
+++ b/biggus/tests/unit/init/test__normalise_axis.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._normalise_axis`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test__sliced_shape.py
+++ b/biggus/tests/unit/init/test__sliced_shape.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus._init._sliced_shape`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test__sliced_shape.py
+++ b/biggus/tests/unit/init/test__sliced_shape.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._sliced_shape`."""
 
+from __future__ import absolute_import
+
 import unittest
 
 import numpy as np

--- a/biggus/tests/unit/init/test__sliced_shape.py
+++ b/biggus/tests/unit/init/test__sliced_shape.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import unittest
 
@@ -70,14 +71,14 @@ class Test__sliced_shape(unittest.TestCase):
     def test_invalid_object_indexing(self):
         keys = key_gen[np.nan]
         msg = 'Invalid indexing object "nan"'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             _sliced_shape([4, 5, 6], keys)
 
     def test_invalid_object_indexing_float(self):
         # A float is a valid indexing object in numpy.
         keys = key_gen[1.2]
         msg = 'Invalid indexing object "1.2"'
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             _sliced_shape([4, 5, 6], keys)
 
     def test_numpy_bool_indexing(self):

--- a/biggus/tests/unit/init/test__sliced_shape.py
+++ b/biggus/tests/unit/init/test__sliced_shape.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._sliced_shape`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test__sliced_shape.py
+++ b/biggus/tests/unit/init/test__sliced_shape.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus._init._sliced_shape`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test__ufunc_wrapper.py
+++ b/biggus/tests/unit/init/test__ufunc_wrapper.py
@@ -57,12 +57,12 @@ class Test__unary_fn_wrapper(unittest.TestCase):
 
     def test_non_ufunc(self):
         msg = 'not a ufunc'
-        with self.assertRaisesRegexp(TypeError, msg):
+        with six.assertRaisesRegex(self, TypeError, msg):
             _ufunc_wrapper(lambda x: x)
 
     def test_nout2_ufunc(self):
         msg = "Unsupported ufunc 'modf' with 1 input arrays & 2 output arrays."
-        with self.assertRaisesRegexp(ValueError, msg):
+        with six.assertRaisesRegex(self, ValueError, msg):
             _ufunc_wrapper(np.modf)
 
     def test_updates_all_default_name(self):

--- a/biggus/tests/unit/init/test__ufunc_wrapper.py
+++ b/biggus/tests/unit/init/test__ufunc_wrapper.py
@@ -22,6 +22,7 @@ has wrapped.
 
 from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
+import six
 
 import inspect
 import unittest
@@ -124,9 +125,9 @@ class Test_wrapped_functions(unittest.TestCase):
                 warnings.simplefilter("always")
                 actual = result.ndarray()
 
-            self.assertEqual([unicode(warning.message)
+            self.assertEqual([six.text_type(warning.message)
                               for warning in actual_warnings],
-                             [unicode(warning.message)
+                             [six.text_type(warning.message)
                               for warning in expected_warnings])
 
             error_msg = ('biggus.{} produces different results to np.{}:'

--- a/biggus/tests/unit/init/test__ufunc_wrapper.py
+++ b/biggus/tests/unit/init/test__ufunc_wrapper.py
@@ -20,7 +20,7 @@ has wrapped.
 
 """
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import unittest

--- a/biggus/tests/unit/init/test__ufunc_wrapper.py
+++ b/biggus/tests/unit/init/test__ufunc_wrapper.py
@@ -20,7 +20,7 @@ has wrapped.
 
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import inspect
 import unittest

--- a/biggus/tests/unit/init/test__ufunc_wrapper.py
+++ b/biggus/tests/unit/init/test__ufunc_wrapper.py
@@ -21,6 +21,7 @@ has wrapped.
 """
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import inspect
 import unittest

--- a/biggus/tests/unit/init/test__ufunc_wrapper.py
+++ b/biggus/tests/unit/init/test__ufunc_wrapper.py
@@ -20,6 +20,8 @@ has wrapped.
 
 """
 
+from __future__ import absolute_import
+
 import inspect
 import unittest
 import warnings

--- a/biggus/tests/unit/init/test__unary_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__unary_fn_wrapper.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015, Met Office
+# (C) British Crown Copyright 2015 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -19,6 +19,8 @@ Unit tests for `biggus._init._unary_fn_wrapper` and the functions that it
 has wrapped.
 
 """
+
+from __future__ import absolute_import
 
 import inspect
 import sys

--- a/biggus/tests/unit/init/test__unary_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__unary_fn_wrapper.py
@@ -20,7 +20,7 @@ has wrapped.
 
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import inspect
 import sys

--- a/biggus/tests/unit/init/test__unary_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__unary_fn_wrapper.py
@@ -21,6 +21,7 @@ has wrapped.
 """
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import inspect
 import sys

--- a/biggus/tests/unit/init/test__unary_fn_wrapper.py
+++ b/biggus/tests/unit/init/test__unary_fn_wrapper.py
@@ -20,7 +20,7 @@ has wrapped.
 
 """
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import sys

--- a/biggus/tests/unit/init/test_count.py
+++ b/biggus/tests/unit/init/test_count.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.count`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_count.py
+++ b/biggus/tests/unit/init/test_count.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.count`."""
+
+from __future__ import absolute_import
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_count.py
+++ b/biggus/tests/unit/init/test_count.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.count`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_count.py
+++ b/biggus/tests/unit/init/test_count.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.count`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_ensure_array.py
+++ b/biggus/tests/unit/init/test_ensure_array.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.ensure_array`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 
@@ -41,7 +42,7 @@ class Test_ensure_array(unittest.TestCase):
 
     def test_other_type(self):
         with self.assertRaises(TypeError):
-            ensure_array(range(10))
+            ensure_array(list(range(10)))
 
 
 if __name__ == '__main__':

--- a/biggus/tests/unit/init/test_ensure_array.py
+++ b/biggus/tests/unit/init/test_ensure_array.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ensure_array`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ensure_array.py
+++ b/biggus/tests/unit/init/test_ensure_array.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ensure_array`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ensure_array.py
+++ b/biggus/tests/unit/init/test_ensure_array.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ensure_array`."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/unit/init/test_max.py
+++ b/biggus/tests/unit/init/test_max.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.max`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_max.py
+++ b/biggus/tests/unit/init/test_max.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.max`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_max.py
+++ b/biggus/tests/unit/init/test_max.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.max`."""
 
+from __future__ import absolute_import
+
 import numpy as np
 import numpy.ma as ma
 import unittest

--- a/biggus/tests/unit/init/test_max.py
+++ b/biggus/tests/unit/init/test_max.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.max`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_mean.py
+++ b/biggus/tests/unit/init/test_mean.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.mean`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_mean.py
+++ b/biggus/tests/unit/init/test_mean.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.mean`."""
+
+from __future__ import absolute_import
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_mean.py
+++ b/biggus/tests/unit/init/test_mean.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.mean`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_mean.py
+++ b/biggus/tests/unit/init/test_mean.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.mean`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_min.py
+++ b/biggus/tests/unit/init/test_min.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.min`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_min.py
+++ b/biggus/tests/unit/init/test_min.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.min`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_min.py
+++ b/biggus/tests/unit/init/test_min.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.min`."""
 
+from __future__ import absolute_import
+
 import numpy as np
 import numpy.ma as ma
 import unittest

--- a/biggus/tests/unit/init/test_min.py
+++ b/biggus/tests/unit/init/test_min.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.min`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_ones.py
+++ b/biggus/tests/unit/init/test_ones.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ones`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ones.py
+++ b/biggus/tests/unit/init/test_ones.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ones`."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ones.py
+++ b/biggus/tests/unit/init/test_ones.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.ones`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_ones.py
+++ b/biggus/tests/unit/init/test_ones.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.ones`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_size.py
+++ b/biggus/tests/unit/init/test_size.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.size`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_size.py
+++ b/biggus/tests/unit/init/test_size.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.size`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_size.py
+++ b/biggus/tests/unit/init/test_size.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.size`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/biggus/tests/unit/init/test_size.py
+++ b/biggus/tests/unit/init/test_size.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.size`."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/unit/init/test_std_var.py
+++ b/biggus/tests/unit/init/test_std_var.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.std` and `biggus.var`."""
+
+from __future__ import absolute_import
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_std_var.py
+++ b/biggus/tests/unit/init/test_std_var.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.std` and `biggus.var`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_std_var.py
+++ b/biggus/tests/unit/init/test_std_var.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.std` and `biggus.var`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_std_var.py
+++ b/biggus/tests/unit/init/test_std_var.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.std` and `biggus.var`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_sum.py
+++ b/biggus/tests/unit/init/test_sum.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.sum`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_sum.py
+++ b/biggus/tests/unit/init/test_sum.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.sum`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_sum.py
+++ b/biggus/tests/unit/init/test_sum.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.sum`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import numpy as np
 import numpy.ma as ma

--- a/biggus/tests/unit/init/test_sum.py
+++ b/biggus/tests/unit/init/test_sum.py
@@ -16,6 +16,8 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.sum`."""
 
+from __future__ import absolute_import
+
 import numpy as np
 import numpy.ma as ma
 import unittest

--- a/biggus/tests/unit/init/test_zeros.py
+++ b/biggus/tests/unit/init/test_zeros.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.zeros`."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import unittest
 

--- a/biggus/tests/unit/init/test_zeros.py
+++ b/biggus/tests/unit/init/test_zeros.py
@@ -17,6 +17,7 @@
 """Unit tests for `biggus.zeros`."""
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
 

--- a/biggus/tests/unit/init/test_zeros.py
+++ b/biggus/tests/unit/init/test_zeros.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of Biggus.
 #
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.zeros`."""
+
+from __future__ import absolute_import
 
 import unittest
 

--- a/biggus/tests/unit/init/test_zeros.py
+++ b/biggus/tests/unit/init/test_zeros.py
@@ -16,7 +16,7 @@
 # along with Biggus. If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for `biggus.zeros`."""
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,6 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import
+
 import sys, os
 
 import sphinx

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import sys, os
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 
 from __future__ import absolute_import, division, print_function
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 import sys, os
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import sys, os
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+six
 numpy
 pep8

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
                  'Programming Language :: Python :: 3.5'],
     description='Virtual large arrays and lazy evaluation',
     long_description=open('README.rst').read(),
-    use_2to3=True,
     test_suite='biggus.tests',
     cmdclass={'clean_source': CleanSource}
 )


### PR DESCRIPTION
2to3 is the old method, and somewhat annoying. You need to run an extra translation step, which is (albeit minimally) slower, and you can't do an editable install because the source is not _really_ Python 3 compatible.

This does add a dependency on six, but I think it's ubiquitous enough now to not be a problem.