### PR TITLE
Convert tuple indices to arrays in NumpyArrayAdapter.ndarray and ArrayStack

### DIFF
--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -804,7 +804,7 @@ class NewAxesArray(ArrayContainer):
                     new_size = len(range(*key.indices(1)))
                     if new_size != 1:
                         broadcast_dict[key_index] = new_size
-                elif isinstance(key, tuple):
+                elif isinstance(key, tuple, np.ndarray):
                     for index in key:
                         if not -1 <= index < 1:
                             raise IndexError('index {} is out of bounds for '
@@ -1519,7 +1519,9 @@ class NumpyArrayAdapter(_ArrayAdapter):
             for i, key in tuple_keys:
                 array = np.take(array, key, axis=dimensions[i])
         else:
-            array = self.concrete.__getitem__(keys)
+            np_keys = tuple(np.array(key) if isinstance(key, tuple) else key
+                            for key in keys)
+            array = self.concrete.__getitem__(np_keys)
         return array
 
 
@@ -1776,7 +1778,8 @@ class ArrayStack(Array):
 
     def _getitem_full_keys(self, keys):
         stack_ndim = self._stack.ndim
-        stack_keys = keys[:stack_ndim]
+        stack_keys = tuple(np.array(key) if isinstance(key, tuple) else key
+                           for key in keys[:stack_ndim])
         item_keys = keys[stack_ndim:]
 
         stack_shape = _sliced_shape(self._stack.shape, stack_keys)

--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -171,8 +171,8 @@ class Test___getitem__(unittest.TestCase):
     # Currently they only handle the newaxis checking.
     # There are more tests in biggus.tests.test_stack.
     def setUp(self):
-        self.a1 = ConstantArray([4, 3])
-        self.a2 = ConstantArray([4, 3])
+        self.a1 = ConstantArray([4, 3], 0)
+        self.a2 = ConstantArray([4, 3], 1)
         self.a = ArrayStack([self.a1, self.a2])
 
     def test_newaxis_leading(self):
@@ -180,6 +180,11 @@ class Test___getitem__(unittest.TestCase):
 
     def test_newaxis_trailing(self):
         self.assertEqual(self.a[..., np.newaxis].shape, (2, 4, 3, 1))
+
+    def test_tuple_indexing(self):
+        # In numpy <=1.8 this would fail if the tuple isn't cast to a np.array
+        assert_array_equal(self.a[((1, 0, 1),)].shape, (3, 4, 3))
+        assert_array_equal(self.a[(1, 0, 1), 0, 0].ndarray(), (1, 0, 1))
 
 
 class Test__deepcopy__(unittest.TestCase):


### PR DESCRIPTION
Stolen from https://github.com/djkirkham/biggus/tree/convert-tuple-indice-to-arrays