### PR TITLE
Np1v8 fix

### DIFF
--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -171,8 +171,8 @@ class Test___getitem__(unittest.TestCase):
     # Currently they only handle the newaxis checking.
     # There are more tests in biggus.tests.test_stack.
     def setUp(self):
-        self.a1 = ConstantArray([4, 3])
-        self.a2 = ConstantArray([4, 3])
+        self.a1 = ConstantArray([4, 3], 0)
+        self.a2 = ConstantArray([4, 3], 1)
         self.a = ArrayStack([self.a1, self.a2])
 
     def test_newaxis_leading(self):
@@ -180,6 +180,11 @@ class Test___getitem__(unittest.TestCase):
 
     def test_newaxis_trailing(self):
         self.assertEqual(self.a[..., np.newaxis].shape, (2, 4, 3, 1))
+
+    def test_tuple_indexing(self):
+        # In numpy <=1.8 this would fail if the tuple isn't cast to a np.array
+        assert_array_equal(self.a[((1, 0, 1),)].shape, (3, 4, 3))
+        assert_array_equal(self.a[(1, 0, 1), 0, 0].ndarray(), (1, 0, 1))
 
 
 class Test__deepcopy__(unittest.TestCase):

--- a/biggus/tests/unit/init/test_NewAxesArray.py
+++ b/biggus/tests/unit/init/test_NewAxesArray.py
@@ -156,12 +156,12 @@ class Test___getitem__(unittest.TestCase):
         self.assertIsInstance(result, NewAxesArray)
         self.assertEqual(list(result._new_axes), [0, 1, 0, 1])
 
-    def test_index_existing_newaxis(self):
+    def test_index_existing_newaxis_2(self):
         result = self.array[0, 0, 0, ..., 0]
         self.assertIsInstance(result, NewAxesArray)
         self.assertEqual(list(result._new_axes), [1, 0, 0])
 
-    def test_index_existing_newaxis(self):
+    def test_index_existing_newaxis_3(self):
         result = self.array[0, 0, 0, 0, 0, 0, 0]
         self.assertIsInstance(result, NewAxesArray)
         self.assertEqual(list(result._new_axes), [0])
@@ -190,10 +190,18 @@ class Test___getitem__(unittest.TestCase):
     def test_new_axis_tuple_indexing(self):
         self.assertEqual(self.array_3d[(0, 0, 0), ...].shape, (3, 3, 1))
 
+    def test_new_axis_numpy_list_indexing(self):
+        self.assertEqual(self.array_3d[[0, 0, 0], ...].shape,
+                         (3, 3, 1))
+
     def test_new_axis_numpy_array_indexing(self):
-        msg = "NewAxesArray indexing not yet supported for ndarray keys."
+        self.assertEqual(self.array_3d[np.array([0, 0, 0]), ...].shape,
+                         (3, 3, 1))
+
+    def test_newaxis_multidim_array_indexing(self):
+        msg = "with multidimensional arrays is not supported"
         with six.assertRaisesRegex(self, NotImplementedError, msg):
-            self.array_3d[np.array([0, 0, 0]), ...]
+            self.array_3d[np.array([[0, 1], [0, 1], [0, 1]]), ...]
 
 
 class Test_ndarray(unittest.TestCase):


### PR DESCRIPTION
This avoids a problem exposed by netcdf saves in Iris 1.10, 
but which is actually due to a bug fixed by the major indexing rewrite in numpy 1.9.
See : https://github.com/SciTools/iris/issues/2120

I've patched all indexing to convert tuples (where the problem was) to lists instead.

Notes:
 * replaces #188, except that this converts tuples to lists instead of arrays
 * converting ***all*** 'vector_key' types did not work, as making arrays into lists upsets the special case of indexing with a boolean array

Checked : the Iris 1.10 tests still pass with these changes.