### PR TITLE
BLD: Updated tested numpy version to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - NUMPY="numpy==1.7"
+  - NUMPY="numpy==1.9"
   - NUMPY="--upgrade numpy"
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
Increase the minimum version of numpy that biggus is tested against with travis CI to 1.9
Matching the minimum requirements of iris.

This would facilitate making changes to biggus which would no longer require to be backward compatible with very old versions of numpy.  In particular #176 would be made considerably simple by this change.