### PR TITLE
Replace vectorize with list comprehension in ArrayStack.__deepcopy__

### DIFF
--- a/biggus/_init.py
+++ b/biggus/_init.py
@@ -1749,10 +1749,10 @@ class ArrayStack(Array):
 
         # Preserve the array ordering by performing an
         # element-wise deepcopy of the stack payload.
-        deepcopy_with_memo = functools.partial(deepcopy, memo=memo)
-        deepcopy_elementwise = np.vectorize(deepcopy_with_memo,
-                                            otypes=[np.object])
-        result = deepcopy_elementwise(self._stack)
+        result = np.array(
+            [deepcopy(array, memo=memo) for array in self._stack.flat],
+            dtype='O')
+        result.shape = self._stack.shape
         memo[id(self._stack)] = result
 
         # Implement a standard deepcopy now we've already dealt

--- a/biggus/tests/unit/init/test_ArrayStack.py
+++ b/biggus/tests/unit/init/test_ArrayStack.py
@@ -199,6 +199,8 @@ class Test__deepcopy__(unittest.TestCase):
                                    order=order, dtype=object))
         copied = copy.deepcopy(orig)
         assert_array_equal(expected, copied.ndarray())
+        for array in copied._stack.flat:
+            self.assertTrue(isinstance(array, NumpyArrayAdapter))
 
     def test_fortran_order(self):
         self.check('f')


### PR DESCRIPTION
When a function created with `numpy.vectorize` is called on a nested sequence or numpy array, it calls its underlying function for each element in each nested sequence. So when given a sequence of biggus arrays, the underlying function is called for each element in those arrays, not on the arrays themselves.

This causes a bug in `ArrayStack.__deepcopy__`; when the `_stack` attribute is deepcopied, rather than creating a new biggus array for each element, a numpy array is created. Not only does this load the data prematurely, it causes errors in other parts of the code which assume `_stack` contains biggus arrays.

This change fixes this bug by replacing the vectorization with a list comprehension.