### PR TITLE
TST: Skip double-ellipsis test with NumPy >= 1.12.0.

### DIFF
--- a/biggus/tests/unit/init/test__full_keys.py
+++ b/biggus/tests/unit/init/test__full_keys.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, division, print_function
 from six.moves import (filter, input, map, range, zip)  # noqa
 
 import unittest
+from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -60,10 +61,14 @@ class Test__full_keys(unittest.TestCase):
         self.assertFullSlice((1, Ellipsis), 2,
                              [1, slice(None)])
 
+    @unittest.skipIf(np.__version__ >= LooseVersion('1.12.0'),
+                     'NumPy 1.12.0 does not support double ellipsis.')
     def test_double_ellipsis(self):
         self.assertFullSlice((1, Ellipsis, 1, Ellipsis), 4,
                              [1, slice(None), 1, slice(None)])
 
+    @unittest.skipIf(np.__version__ >= LooseVersion('1.12.0'),
+                     'NumPy 1.12.0 does not support double ellipsis.')
     def test_double_ellipsis_new_axis(self):
         self.assertFullSlice((1, Ellipsis, 1, np.newaxis, Ellipsis), 4,
                              [1, slice(None), 1, None, slice(None)])
@@ -81,6 +86,8 @@ class Test__full_keys(unittest.TestCase):
         self.assertFullSlice((np.newaxis, Ellipsis, None, np.newaxis), 2,
                              [None, slice(None), slice(None), None, None])
 
+    @unittest.skipIf(np.__version__ >= LooseVersion('1.12.0'),
+                     'NumPy 1.12.0 does not support double ellipsis.')
     def test_redundant_ellipsis(self):
         keys = (slice(None), Ellipsis, 0, Ellipsis, slice(None))
         self.assertFullSlice(keys, 4,


### PR DESCRIPTION
It is no longer supported.

Eventually, should make a decision on whether biggus should support this too.